### PR TITLE
[FEAT] Spring WebFlux 프로젝트 공통 부분 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,12 @@ java {
     }
 }
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }
@@ -29,6 +35,10 @@ dependencies {
 
     /* Database */
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    /* Lombok */
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     /* Tests */
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/art/snail/naillian/backend/attributes/GlobalErrorAttributes.java
+++ b/src/main/java/art/snail/naillian/backend/attributes/GlobalErrorAttributes.java
@@ -1,0 +1,35 @@
+package art.snail.naillian.backend.attributes;
+
+import art.snail.naillian.backend.errors.ReportableError;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import java.util.Map;
+
+/**
+ * 전역에서 발생하는 Exception 의 유형에 따라 body 를 재정의하기 위한
+ */
+@Component
+public class GlobalErrorAttributes extends DefaultErrorAttributes {
+    private static final Logger log = LogManager.getLogger(GlobalErrorAttributes.class);
+
+    @Override
+    public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {
+        Map<String, Object> attributes = super.getErrorAttributes(request, options);
+
+        Throwable ex = getError(request);
+        if (ex instanceof ReportableError) {
+            attributes.clear();
+            attributes.put("code", ((ReportableError) ex).getStatus().value());
+            attributes.put("message", ex.getMessage());
+        } else {
+            log.warn("Unhandled error", ex);
+        }
+
+        return attributes;
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/common/CommonController.java
+++ b/src/main/java/art/snail/naillian/backend/common/CommonController.java
@@ -1,0 +1,17 @@
+package art.snail.naillian.backend.common;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+public class CommonController {
+    public Mono<ServerResponse> streamHelloWorld(ServerRequest request) {
+        return ServerResponse.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(Flux.just("Hello, ", "world!"), String.class);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/config/AuthConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/AuthConfig.java
@@ -1,0 +1,22 @@
+package art.snail.naillian.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class AuthConfig {
+    private static final String[] PUBLIC_ROUTES = {
+            "/",
+    };
+
+    @Bean
+    SecurityWebFilterChain defaultSecurityFilterChain(ServerHttpSecurity http) throws Exception {
+        return http
+                .authorizeExchange(exchange -> exchange.anyExchange().permitAll())
+                .build();
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/config/RouteConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/RouteConfig.java
@@ -1,6 +1,6 @@
 package art.snail.naillian.backend.config;
 
-import art.snail.naillian.backend.common.CommonController;
+import art.snail.naillian.backend.routes.common.CommonController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/art/snail/naillian/backend/config/RouteConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/RouteConfig.java
@@ -1,0 +1,22 @@
+package art.snail.naillian.backend.config;
+
+import art.snail.naillian.backend.common.CommonController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class RouteConfig {
+    @Autowired
+    private CommonController commonController;
+
+    @Bean
+    public RouterFunction<ServerResponse> route() {
+        return RouterFunctions.route()
+                .GET("/", commonController::streamHelloWorld)
+                .build();
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/errors/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/art/snail/naillian/backend/errors/GlobalErrorWebExceptionHandler.java
@@ -1,0 +1,63 @@
+package art.snail.naillian.backend.errors;
+
+import art.snail.naillian.backend.attributes.GlobalErrorAttributes;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.*;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+/**
+ * 전역에서 발생하는 오류를 커스텀하고 ServerResponse 를 생성하는 Handler
+ */
+@Component
+@Order(-2)
+public class GlobalErrorWebExceptionHandler extends AbstractErrorWebExceptionHandler {
+    private static final HttpStatusCode DEFAULT_CODE = HttpStatus.BAD_GATEWAY;
+
+    public GlobalErrorWebExceptionHandler(
+            GlobalErrorAttributes errorAttributes,
+            ApplicationContext applicationContext,
+            ServerCodecConfigurer serverCodecConfigurer
+    ) {
+        super(errorAttributes, new WebProperties.Resources(), applicationContext);
+        super.setMessageReaders(serverCodecConfigurer.getReaders());
+        super.setMessageWriters(serverCodecConfigurer.getWriters());
+    }
+
+    @Override
+    protected RouterFunction<ServerResponse> getRoutingFunction(ErrorAttributes errorAttributes) {
+        // 전역의 오류를 catch 함
+        return RouterFunctions.route(RequestPredicates.all(), this::renderErrorResponse);
+    }
+
+    /**
+     * 오류로 생성된 Map 데이터를 JSON 으로 변환함
+     */
+    private Mono<ServerResponse> renderErrorResponse(ServerRequest request) {
+        Map<String, Object> errorProperties = getErrorAttributes(request, ErrorAttributeOptions.defaults());
+
+        HttpStatusCode code = DEFAULT_CODE;
+        try {
+            Integer rawCode = (Integer) errorProperties.get("code");
+            code = HttpStatusCode.valueOf(rawCode);
+        } catch (AssertionError ignored) {
+            // code 가 엉뚱한 값이 들어오면 무시하고 기본값을 사용함
+        }
+
+        return ServerResponse.status(code)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(errorProperties));
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/errors/ReportableError.java
+++ b/src/main/java/art/snail/naillian/backend/errors/ReportableError.java
@@ -1,0 +1,27 @@
+package art.snail.naillian.backend.errors;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 이용자에게 오류 응답을 전송할 수 있는 RuntimeException
+ *
+ * @see art.snail.naillian.backend.attributes.GlobalErrorAttributes
+ * @see art.snail.naillian.backend.errors.GlobalErrorWebExceptionHandler
+ */
+@Getter
+@AllArgsConstructor
+public class ReportableError extends RuntimeException {
+    private final HttpStatus status;
+    private final String message;
+    private final Object data;
+
+    public ReportableError(HttpStatus status) {
+        this(status, status.getReasonPhrase(), null);
+    }
+
+    public ReportableError(HttpStatus status, String message) {
+        this(status, message, null);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/routes/common/CommonController.java
+++ b/src/main/java/art/snail/naillian/backend/routes/common/CommonController.java
@@ -1,4 +1,4 @@
-package art.snail.naillian.backend.common;
+package art.snail.naillian.backend.routes.common;
 
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. 공통 응답부가 code, message, data 로 결정되어 있긴 하지만, Mono/Flux의 활용에 따라 공통 응답부 설정이 어려울 것을 고려하여 추후 적용하기 위해 미포함하였음
2. Spring Security는 일단 모든 엔드포인트에 대해 허용(permit) 으로 설정해두었음. 추후 JWT 인증 로직과 연결 개발 필요


