### PR TITLE
[FEAT] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     /* Database */
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.mariadb:r2dbc-mariadb:1.1.3'
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
     /* Lombok */
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,11 @@ dependencies {
     implementation boot('starter-oauth2-client')
     implementation boot('starter-security')
     implementation boot('starter-webflux')
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 
     /* Database */
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    implementation 'org.mariadb:r2dbc-mariadb:1.1.3'
 
     /* Lombok */
     compileOnly 'org.projectlombok:lombok'
@@ -45,6 +47,18 @@ dependencies {
     testImplementation boot('starter-test')
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'io.projectreactor:reactor-test'
+
+    /* jwt */
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    /* redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'io.r2dbc:r2dbc-h2' // H2 R2DBC 드라이버 추가
+    implementation 'com.h2database:h2' // H2 JDBC 드라이버 (테스트용)
+
 }
 
 tasks.named('test') {

--- a/src/main/java/art/snail/naillian/backend/config/JacksonConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package art.snail.naillian.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/config/RedisConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/RedisConfig.java
@@ -1,0 +1,16 @@
+package art.snail.naillian.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    /** Redis 연결을 위한 StringRedisTemplate 빈 등록 */
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/config/WebClientConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package art.snail.naillian.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,72 @@
+package art.snail.naillian.backend.domain.auth.controller;
+
+import art.snail.naillian.backend.domain.auth.service.KakaoAuthService;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private static final Logger log = LoggerFactory.getLogger(KakaoAuthService.class);
+
+
+    private final KakaoAuthService kakaoAuthService;
+
+    /** 1. 카카오 로그인(GET /kakao/login/{code}) */
+    @GetMapping("/kakao/login/{code}")
+    public Mono<ResponseEntity<Map<String, Object>>> kakaoLogin(@PathVariable String code) {
+        log.info("카카오 로그인 API 호출 - 받은 코드: {}", code);
+
+        return kakaoAuthService.getAccessToken(code)
+                .flatMap(token -> {
+                    log.info("받은 AccessToken: {}", token);
+                    return kakaoAuthService.getUserInfo(token);
+                })
+                .flatMap(user -> kakaoAuthService.generateJwtTokens(user)
+                        .map(tokens -> {
+                            log.info("JWT 토큰 발급 완료 - 닉네임: {}, AccessToken: {}, RefreshToken: {}",
+                                    user.getNickname(), tokens.get("accessToken"), tokens.get("refreshToken"));
+
+                            Map<String, Object> responseBody = Map.of(
+                                    "nickname", user.getNickname(),
+                                    "accessToken", tokens.get("accessToken"),
+                                    "refreshToken", tokens.get("refreshToken")
+                            );
+
+                            return ResponseEntity.ok(responseBody);
+                        }))
+                .onErrorResume(error -> {
+                    log.error("카카오 로그인 API 오류 발생", error);
+
+                    Map<String, Object> errorResponse = Map.of(
+                            "error", "카카오 로그인 실패",
+                            "message", error.getMessage()
+                    );
+
+                    return Mono.just(ResponseEntity.badRequest().body(errorResponse));
+                });
+    }
+
+    @GetMapping("/callback/auth/kakao")
+    public Mono<ResponseEntity<String>> handleCallback(@RequestParam(name = "code", required = false) String code) {
+        if (code == null) {
+            log.error("카카오에서 code가 전달되지 않음");
+            return Mono.just(ResponseEntity.badRequest().body("카카오에서 code가 전달되지 않았습니다."));
+        }
+        log.info("카카오 인증 코드: {}", code);
+        return Mono.just(ResponseEntity.ok("Received code: " + code));
+    }
+
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/controller/AuthController.java
@@ -59,7 +59,7 @@ public class AuthController {
                 });
     }
 
-    @GetMapping("/callback/auth/kakao")
+    @GetMapping("/kakao")
     public Mono<ResponseEntity<String>> handleCallback(@RequestParam(name = "code", required = false) String code) {
         if (code == null) {
             log.error("카카오에서 code가 전달되지 않음");

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
@@ -4,6 +4,7 @@ import art.snail.naillian.backend.errors.ReportableError;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import io.micrometer.common.lang.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
@@ -24,19 +25,27 @@ public class JwtProvider {
     }
 
     public String generateAccessToken(Integer userId) {
+        return generateAccessToken(userId, new Date());
+    }
+
+    public String generateAccessToken(Integer userId, @Nullable Date issueDate) {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION))
+                .setIssuedAt(issueDate != null ? issueDate : new Date()) // ✅ issueDate 없으면 현재 시간
+                .setExpiration(new Date(issueDate != null ? issueDate.getTime() + ACCESS_EXPIRATION : System.currentTimeMillis() + ACCESS_EXPIRATION))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
     public String generateRefreshToken(Integer userId) {
+        return generateRefreshToken(userId, new Date());
+    }
+
+    public String generateRefreshToken(Integer userId, @Nullable Date issueDate) {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRATION))
+                .setIssuedAt(issueDate != null ? issueDate : new Date()) // issueDate 없으면 현재 시간
+                .setExpiration(new Date(issueDate != null ? issueDate.getTime() + REFRESH_EXPIRATION : System.currentTimeMillis() + REFRESH_EXPIRATION))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
@@ -1,0 +1,58 @@
+package art.snail.naillian.backend.domain.auth.jwt;
+
+import art.snail.naillian.backend.errors.ReportableError;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+    private static final long ACCESS_EXPIRATION = 1000 * 60 * 30;
+    private static final long REFRESH_EXPIRATION = 1000 * 60 * 30;
+
+    public JwtProvider(@Value("${jwt.secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Integer userId) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Integer userId) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRATION))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Mono<Integer> getUserIdFromToken(String token) {
+        try {
+            Integer userId = Integer.parseInt(Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject());
+            return Mono.just(userId);
+        } catch (Exception e) {
+            return Mono.error(new ReportableError(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다.", 401));
+        }
+    }
+
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/AuthenticationService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/AuthenticationService.java
@@ -1,0 +1,40 @@
+package art.snail.naillian.backend.domain.auth.service;
+
+import art.snail.naillian.backend.domain.auth.jwt.JwtProvider;
+import art.snail.naillian.backend.domain.user.entity.User;
+import art.snail.naillian.backend.domain.user.repository.UserRepository;
+import art.snail.naillian.backend.errors.ReportableError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService {
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    /** Access Token 검증 및 사용자 ID 추출 */
+    public Mono<Integer> extractUserIdFromToken(String authorizationHeader) {
+        return Mono.justOrEmpty(authorizationHeader)
+                .map(this::parseToken)
+                .flatMap(jwtProvider::getUserIdFromToken)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.UNAUTHORIZED ,"유효하지 않은 인증 정보입니다.")));
+    }
+
+    /** AccessToken을 통해 사용자 조회 */
+    public Mono<User> getUserFromToken(String authorizationHeader) {
+        return extractUserIdFromToken(authorizationHeader)
+                .flatMap(userRepository::findById)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다.")));
+    }
+
+    /** Beaer 토큰에서 실제 토큰 값 추출 */
+    private String parseToken(String authorizationHeader) {
+        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new ReportableError(HttpStatus.UNAUTHORIZED, "인증 토큰이 필요합니다.", 401);
+        }
+        return authorizationHeader.substring(7);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
@@ -72,42 +72,47 @@ public class KakaoAuthService {
     public Mono<User> getUserInfo(String accessTokenJson) {
         log.info("[log]사용자 정보 조회 요청 - AccessToken JSON: {}", accessTokenJson);
 
-        String accessToken;
-        try {
-            JsonNode tokenNode = new ObjectMapper().readTree(accessTokenJson);
-            accessToken = tokenNode.get("access_token").asText();
-        } catch (Exception e) {
-            log.error("[log]AccessToken JSON 파싱 오류", e);
-            return Mono.error(new RuntimeException("[log]AccessToken JSON 파싱 오류", e));
-        }
-
-        log.info("[log]실제 API 요청에 사용될 AccessToken: {}", accessToken);
-
-        return webClient.get()
-                .uri(USER_INFO_URI)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .doOnSuccess(jsonNode -> log.info("[log]카카오 사용자 정보 응답: {}", jsonNode))
-                .flatMap(jsonNode -> {
-                    if (!jsonNode.has("id")) {
-                        log.error("[log]카카오 응답에 사용자 ID 없음: {}", jsonNode);
-                        return Mono.error(new RuntimeException("[log]카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
+        return Mono.fromCallable(() -> new ObjectMapper().readTree(accessTokenJson))
+                .onErrorResume(e -> {
+                    log.error("[log]AccessToken JSON 파싱 오류", e);
+                    return Mono.error(new RuntimeException("[log]AccessToken JSON 파싱 오류", e));
+                })
+                .flatMap(tokenNode -> {
+                    if (!tokenNode.has("access_token") || !tokenNode.get("access_token").isTextual()) {
+                        log.error("[log]AccessToken JSON에 'access_token' 키가 없거나 잘못된 형식입니다: {}", tokenNode);
+                        return Mono.error(new RuntimeException("[log]올바른 'access_token' 값을 찾을 수 없습니다."));
                     }
 
-                    String platformUserId = jsonNode.get("id").asText();
-                    String nickname = jsonNode.path("properties").path("nickname").asText();
-                    log.info("[log]카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+                    String accessToken = tokenNode.get("access_token").asText();
+                    log.info("[log]실제 API 요청에 사용될 AccessToken: {}", accessToken);
 
-                    return socialLoginRepository.findByPlatformUserId(platformUserId)
-                            .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
-                            .switchIfEmpty(createNewUser(platformUserId, nickname));
-                })
-                .onErrorResume(e -> {
-                    log.error("[log]사용자 정보 조회 중 오류 발생", e);
-                    return Mono.error(new RuntimeException("[log]사용자 정보 조회 실패", e));
+                    return webClient.get()
+                            .uri(USER_INFO_URI)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .retrieve()
+                            .bodyToMono(JsonNode.class)
+                            .doOnSuccess(jsonNode -> log.info("[log]카카오 사용자 정보 응답: {}", jsonNode))
+                            .flatMap(jsonNode -> {
+                                if (!jsonNode.has("id") || !jsonNode.get("id").isTextual()) {
+                                    log.error("[log]카카오 응답에 사용자 ID 없음: {}", jsonNode);
+                                    return Mono.error(new RuntimeException("[log]카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
+                                }
+
+                                String platformUserId = jsonNode.get("id").asText();
+                                String nickname = jsonNode.path("properties").path("nickname").asText();
+                                log.info("[log]카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+
+                                return socialLoginRepository.findByPlatformUserId(platformUserId)
+                                        .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
+                                        .switchIfEmpty(createNewUser(platformUserId, nickname));
+                            })
+                            .onErrorResume(e -> {
+                                log.error("[log]사용자 정보 조회 중 오류 발생", e);
+                                return Mono.error(new RuntimeException("[log]사용자 정보 조회 실패", e));
+                            });
                 });
     }
+
 
 
 

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
@@ -6,10 +6,11 @@ import art.snail.naillian.backend.domain.user.entity.User;
 import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -19,6 +20,7 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class KakaoAuthService {
+
 
     private static final Logger log = LoggerFactory.getLogger(KakaoAuthService.class);
 
@@ -33,60 +35,78 @@ public class KakaoAuthService {
     @Value("${kakao.auth.callback-url}")
     private String callbackUrl;
 
+    @Value("${kakao.auth.client-secret:}")
+    private String clientSecret;
+
+
     private final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
     private final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
 
     /** 1. 카카오 액세스 토큰 요청 */
 
     public Mono<String> getAccessToken(String code) {
-        log.info("🔍 카카오 토큰 요청: code={}", code);
+        log.info("[log] 카카오 토큰 요청 시작 - 받은 코드: {}", code);
+        log.info("[log] 클라이언트 ID: {}", restApiKey);
+        log.info("[log] 리디렉트 URI: {}", callbackUrl);
 
-        return webClient.post()
+        WebClient.RequestHeadersSpec<?> request = webClient.post()
                 .uri(TOKEN_URI)
-                .header("Content-Type", "application/x-www-form-urlencoded") // ✅ 헤더 추가
+                .header("Content-Type", "application/x-www-form-urlencoded")
                 .body(BodyInserters.fromFormData("grant_type", "authorization_code")
                         .with("client_id", restApiKey)
                         .with("redirect_uri", callbackUrl)
-                        .with("code", code))
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .doOnSuccess(jsonNode -> log.info("카카오 API 응답: {}", jsonNode))
-                .map(jsonNode -> jsonNode.get("access_token").asText())
-                .doOnSuccess(token -> log.info("카카오 API AccessToken 받음: {}", token))
-                .doOnError(error -> log.error("카카오 API 요청 실패: {}", error.getMessage()));
+                        .with("code", code)
+                        .with("client_secret", clientSecret) // 🔥 client_secret 추가
+                );
+
+        return request.exchangeToMono(response -> {
+                    log.info("[log] 카카오 응답 상태 코드: {}", response.statusCode());
+                    return response.bodyToMono(String.class);
+                })
+                .doOnSuccess(response -> log.info("[log] 카카오 응답 본문: {}", response))
+                .doOnError(error -> log.error("[log] 카카오 API 요청 실패: {}", error.getMessage()));
     }
-
-
 
     /** 사용자 정보 조회 후 DB 저장 */
-    public Mono<User> getUserInfo(String accessToken) {
-        log.info("받은 카카오 AccessToken: {}", accessToken);
+    public Mono<User> getUserInfo(String accessTokenJson) {
+        log.info("[log]사용자 정보 조회 요청 - AccessToken JSON: {}", accessTokenJson);
 
-        return webClient.get()
-                .uri(USER_INFO_URI)
-                .headers(headers -> headers.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .doOnSuccess(jsonNode -> log.info("카카오 사용자 정보 응답: {}", jsonNode)) // 응답 로그 추가
-                .flatMap(jsonNode -> {
-                    if (!jsonNode.has("id")) {
-                        log.error("카카오 응답에 사용자 ID 없음: {}", jsonNode);
-                        return Mono.error(new RuntimeException("카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
-                    }
+        try {
+            JsonNode tokenNode = new ObjectMapper().readTree(accessTokenJson);
+            String accessToken = tokenNode.get("access_token").asText();
 
-                    String platformUserId = jsonNode.get("id").asText();
-                    String nickname = jsonNode.path("properties").path("nickname").asText();
-                    log.info("카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+            log.info("[log]실제 API 요청에 사용될 AccessToken: {}", accessToken);
 
-                    return socialLoginRepository.findByPlatformUserId(platformUserId)
-                            .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
-                            .switchIfEmpty(createNewUser(platformUserId, nickname));
-                })
-                .onErrorResume(e -> {
-                    log.error("사용자 정보 조회 중 오류 발생", e);
-                    return Mono.error(new RuntimeException("사용자 정보 조회 실패", e));
-                });
+            return webClient.get()
+                    .uri(USER_INFO_URI)
+                    .header("Authorization", "Bearer " + accessToken) // 🔥 AccessToken만 전달해야 함
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .doOnSuccess(jsonNode -> log.info("[log]카카오 사용자 정보 응답: {}", jsonNode))
+                    .flatMap(jsonNode -> {
+                        if (!jsonNode.has("id")) {
+                            log.error("[log]카카오 응답에 사용자 ID 없음: {}", jsonNode);
+                            return Mono.error(new RuntimeException("[log]카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
+                        }
+
+                        String platformUserId = jsonNode.get("id").asText();
+                        String nickname = jsonNode.path("properties").path("nickname").asText();
+                        log.info("[log]카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+
+                        return socialLoginRepository.findByPlatformUserId(platformUserId)
+                                .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
+                                .switchIfEmpty(createNewUser(platformUserId, nickname));
+                    })
+                    .onErrorResume(e -> {
+                        log.error("[log]사용자 정보 조회 중 오류 발생", e);
+                        return Mono.error(new RuntimeException("[log]사용자 정보 조회 실패", e));
+                    });
+        } catch (Exception e) {
+            log.error("[log]AccessToken JSON 파싱 오류", e);
+            return Mono.error(new RuntimeException("[log]AccessToken JSON 파싱 오류", e));
+        }
     }
+
 
 
     /** 새로운 사용자 생성 */

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
@@ -1,0 +1,116 @@
+package art.snail.naillian.backend.domain.auth.service;
+
+import art.snail.naillian.backend.domain.auth.jwt.JwtProvider;
+import art.snail.naillian.backend.domain.user.entity.SocialLogin;
+import art.snail.naillian.backend.domain.user.entity.User;
+import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
+import art.snail.naillian.backend.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(KakaoAuthService.class);
+
+    private final WebClient webClient;
+    private final UserRepository userRepository;
+    private final SocialLoginRepository socialLoginRepository;
+    private final JwtProvider jwtProvider;
+
+    @Value("${kakao.auth.rest-api-key}")
+    private String restApiKey;
+
+    @Value("${kakao.auth.callback-url}")
+    private String callbackUrl;
+
+    private final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
+    private final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    /** 1. 카카오 액세스 토큰 요청 */
+
+    public Mono<String> getAccessToken(String code) {
+        log.info("🔍 카카오 토큰 요청: code={}", code);
+
+        return webClient.post()
+                .uri(TOKEN_URI)
+                .header("Content-Type", "application/x-www-form-urlencoded") // ✅ 헤더 추가
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", restApiKey)
+                        .with("redirect_uri", callbackUrl)
+                        .with("code", code))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .doOnSuccess(jsonNode -> log.info("카카오 API 응답: {}", jsonNode))
+                .map(jsonNode -> jsonNode.get("access_token").asText())
+                .doOnSuccess(token -> log.info("카카오 API AccessToken 받음: {}", token))
+                .doOnError(error -> log.error("카카오 API 요청 실패: {}", error.getMessage()));
+    }
+
+
+
+    /** 사용자 정보 조회 후 DB 저장 */
+    public Mono<User> getUserInfo(String accessToken) {
+        log.info("받은 카카오 AccessToken: {}", accessToken);
+
+        return webClient.get()
+                .uri(USER_INFO_URI)
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .doOnSuccess(jsonNode -> log.info("카카오 사용자 정보 응답: {}", jsonNode)) // 응답 로그 추가
+                .flatMap(jsonNode -> {
+                    if (!jsonNode.has("id")) {
+                        log.error("카카오 응답에 사용자 ID 없음: {}", jsonNode);
+                        return Mono.error(new RuntimeException("카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
+                    }
+
+                    String platformUserId = jsonNode.get("id").asText();
+                    String nickname = jsonNode.path("properties").path("nickname").asText();
+                    log.info("카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+
+                    return socialLoginRepository.findByPlatformUserId(platformUserId)
+                            .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
+                            .switchIfEmpty(createNewUser(platformUserId, nickname));
+                })
+                .onErrorResume(e -> {
+                    log.error("사용자 정보 조회 중 오류 발생", e);
+                    return Mono.error(new RuntimeException("사용자 정보 조회 실패", e));
+                });
+    }
+
+
+    /** 새로운 사용자 생성 */
+    private Mono<User> createNewUser(String platformUserId, String nickname) {
+        return userRepository.save(
+                        User.builder()
+                                .nickname(nickname)
+                                .userType("KAKAO")
+                                .registeredIp("UNKNOWN")
+                                .build()
+                )
+                .flatMap(user -> socialLoginRepository.save(
+                        SocialLogin.builder()
+                                .userId(user.getId())
+                                .platform("KAKAO")
+                                .platformUserId(platformUserId)
+                                .build()
+                ).thenReturn(user));
+    }
+
+    public Mono<Map<String, String>> generateJwtTokens(User user) {
+        return Mono.just(Map.of(
+                "accessToken", jwtProvider.generateAccessToken(user.getId()),
+                "refreshToken", jwtProvider.generateRefreshToken(user.getId())
+        ));
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
@@ -91,20 +91,19 @@ public class KakaoAuthService {
                             .header("Authorization", "Bearer " + accessToken)
                             .retrieve()
                             .bodyToMono(JsonNode.class)
-                            .doOnSuccess(jsonNode -> log.info("[log]카카오 사용자 정보 응답: {}", jsonNode))
+                            .doOnSuccess(jsonNode -> log.info("[DEBUG] 카카오 응답 중간 확인: {}", jsonNode))
                             .flatMap(jsonNode -> {
-                                if (!jsonNode.has("id") || !jsonNode.get("id").isTextual()) {
+                                if (!jsonNode.has("id") || !jsonNode.get("id").isNumber()) {
                                     log.error("[log]카카오 응답에 사용자 ID 없음: {}", jsonNode);
                                     return Mono.error(new RuntimeException("[log]카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
                                 }
 
-                                String platformUserId = jsonNode.get("id").asText();
-                                String nickname = jsonNode.path("properties").path("nickname").asText();
-                                log.info("[log]카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+                                String platformUserId = String.valueOf(jsonNode.get("id").asLong());
+                                log.info("[DEBUG] 추출된 사용자 ID: {}", platformUserId);
 
                                 return socialLoginRepository.findByPlatformUserId(platformUserId)
                                         .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
-                                        .switchIfEmpty(createNewUser(platformUserId, nickname));
+                                        .switchIfEmpty(createNewUser(platformUserId, jsonNode.path("properties").path("nickname").asText()));
                             })
                             .onErrorResume(e -> {
                                 log.error("[log]사용자 정보 조회 중 오류 발생", e);
@@ -112,6 +111,7 @@ public class KakaoAuthService {
                             });
                 });
     }
+
 
 
 

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/KakaoAuthService.java
@@ -3,6 +3,7 @@ package art.snail.naillian.backend.domain.auth.service;
 import art.snail.naillian.backend.domain.auth.jwt.JwtProvider;
 import art.snail.naillian.backend.domain.user.entity.SocialLogin;
 import art.snail.naillian.backend.domain.user.entity.User;
+import art.snail.naillian.backend.domain.user.entity.UserType;
 import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -56,7 +57,7 @@ public class KakaoAuthService {
                         .with("client_id", restApiKey)
                         .with("redirect_uri", callbackUrl)
                         .with("code", code)
-                        .with("client_secret", clientSecret) // 🔥 client_secret 추가
+                        .with("client_secret", clientSecret)
                 );
 
         return request.exchangeToMono(response -> {
@@ -71,40 +72,41 @@ public class KakaoAuthService {
     public Mono<User> getUserInfo(String accessTokenJson) {
         log.info("[log]사용자 정보 조회 요청 - AccessToken JSON: {}", accessTokenJson);
 
+        String accessToken;
         try {
             JsonNode tokenNode = new ObjectMapper().readTree(accessTokenJson);
-            String accessToken = tokenNode.get("access_token").asText();
-
-            log.info("[log]실제 API 요청에 사용될 AccessToken: {}", accessToken);
-
-            return webClient.get()
-                    .uri(USER_INFO_URI)
-                    .header("Authorization", "Bearer " + accessToken) // 🔥 AccessToken만 전달해야 함
-                    .retrieve()
-                    .bodyToMono(JsonNode.class)
-                    .doOnSuccess(jsonNode -> log.info("[log]카카오 사용자 정보 응답: {}", jsonNode))
-                    .flatMap(jsonNode -> {
-                        if (!jsonNode.has("id")) {
-                            log.error("[log]카카오 응답에 사용자 ID 없음: {}", jsonNode);
-                            return Mono.error(new RuntimeException("[log]카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
-                        }
-
-                        String platformUserId = jsonNode.get("id").asText();
-                        String nickname = jsonNode.path("properties").path("nickname").asText();
-                        log.info("[log]카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
-
-                        return socialLoginRepository.findByPlatformUserId(platformUserId)
-                                .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
-                                .switchIfEmpty(createNewUser(platformUserId, nickname));
-                    })
-                    .onErrorResume(e -> {
-                        log.error("[log]사용자 정보 조회 중 오류 발생", e);
-                        return Mono.error(new RuntimeException("[log]사용자 정보 조회 실패", e));
-                    });
+            accessToken = tokenNode.get("access_token").asText();
         } catch (Exception e) {
             log.error("[log]AccessToken JSON 파싱 오류", e);
             return Mono.error(new RuntimeException("[log]AccessToken JSON 파싱 오류", e));
         }
+
+        log.info("[log]실제 API 요청에 사용될 AccessToken: {}", accessToken);
+
+        return webClient.get()
+                .uri(USER_INFO_URI)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .doOnSuccess(jsonNode -> log.info("[log]카카오 사용자 정보 응답: {}", jsonNode))
+                .flatMap(jsonNode -> {
+                    if (!jsonNode.has("id")) {
+                        log.error("[log]카카오 응답에 사용자 ID 없음: {}", jsonNode);
+                        return Mono.error(new RuntimeException("[log]카카오 응답에서 사용자 정보를 찾을 수 없습니다."));
+                    }
+
+                    String platformUserId = jsonNode.get("id").asText();
+                    String nickname = jsonNode.path("properties").path("nickname").asText();
+                    log.info("[log]카카오 사용자 ID: {}, 닉네임: {}", platformUserId, nickname);
+
+                    return socialLoginRepository.findByPlatformUserId(platformUserId)
+                            .flatMap(socialLogin -> userRepository.findById(socialLogin.getUserId()))
+                            .switchIfEmpty(createNewUser(platformUserId, nickname));
+                })
+                .onErrorResume(e -> {
+                    log.error("[log]사용자 정보 조회 중 오류 발생", e);
+                    return Mono.error(new RuntimeException("[log]사용자 정보 조회 실패", e));
+                });
     }
 
 
@@ -114,7 +116,7 @@ public class KakaoAuthService {
         return userRepository.save(
                         User.builder()
                                 .nickname(nickname)
-                                .userType("KAKAO")
+                                .userType(UserType.CUSTOMER)
                                 .registeredIp("UNKNOWN")
                                 .build()
                 )

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/TokenService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/TokenService.java
@@ -11,9 +11,9 @@ public class TokenService {
     private final StringRedisTemplate redisTemplate;
 
     /** Redis에 accessToken -> refresh Token 저장 및 userId 저장 */
-    public void storeTokenPair(String accessToken, String refreshToken, Integer userId){
-        redisTemplate.opsForValue().set("token" + accessToken, refreshToken, 30, TimeUnit.MINUTES);
-        redisTemplate.opsForValue().set("refresh" + refreshToken, userId.toString(), 7, TimeUnit.DAYS);
+    public void storeTokenPair(String accessToken, String refreshToken, Integer userId) {
+        redisTemplate.opsForValue().set("token:" + accessToken, refreshToken, 30, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set("refresh:" + refreshToken, userId.toString(), 7, TimeUnit.DAYS);
     }
 
     /** RefreshToken 검증(AccessToken과 매칭) */

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/TokenService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/TokenService.java
@@ -1,0 +1,34 @@
+package art.snail.naillian.backend.domain.auth.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final StringRedisTemplate redisTemplate;
+
+    /** Redis에 accessToken -> refresh Token 저장 및 userId 저장 */
+    public void storeTokenPair(String accessToken, String refreshToken, Integer userId){
+        redisTemplate.opsForValue().set("token" + accessToken, refreshToken, 30, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set("refresh" + refreshToken, userId.toString(), 7, TimeUnit.DAYS);
+    }
+
+    /** RefreshToken 검증(AccessToken과 매칭) */
+    public boolean validateRefreshToken(String accessToken, String refreshToken){
+        String storedRefreshToken = redisTemplate.opsForValue().get("token" + accessToken);
+        return storedRefreshToken != null && storedRefreshToken.equals(refreshToken);
+    }
+
+    /** RefreshToken 사용 시 기존 AccessToken 폐기 */
+    public void invalidateAccessToken(String accessToken){
+        redisTemplate.delete("token" + accessToken);
+    }
+
+    /** RefreshToken 사용시 기존 RefreshToken도 폐기 */
+    public void invalidateRefreshToken(String refreshToken){
+        redisTemplate.delete("refresh" + refreshToken);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package art.snail.naillian.backend.domain.user.controller;
+
+
+import art.snail.naillian.backend.domain.auth.service.AuthenticationService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+    private final AuthenticationService authenticationService;
+
+    /** 사용자 조회 */
+    @GetMapping("/me")
+    public Mono<ResponseEntity<Map<String, Object>>> getUserInfo(@RequestHeader("Authorization") String accessToken) {
+        return authenticationService.getUserFromToken(accessToken)
+                .map(user -> ResponseEntity.ok(Map.of(
+                        "code", 200,
+                        "message", "사용자 정보 조회 성공",
+                        "data", Map.of(
+                                "userId", user.getId(),
+                                "nickname", user.getNickname(),
+                                "profileImageUrl", user.getProfileImageUrl(),
+                                "createdAt", user.getCreatedAt()
+                        )
+                )));
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package art.snail.naillian.backend.domain.user.controller;
 
 
 import art.snail.naillian.backend.domain.auth.service.AuthenticationService;
+import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,15 +22,13 @@ public class UserController {
     @GetMapping("/me")
     public Mono<ResponseEntity<Map<String, Object>>> getUserInfo(@RequestHeader("Authorization") String accessToken) {
         return authenticationService.getUserFromToken(accessToken)
-                .map(user -> ResponseEntity.ok(Map.of(
-                        "code", 200,
-                        "message", "사용자 정보 조회 성공",
-                        "data", Map.of(
-                                "userId", user.getId(),
-                                "nickname", user.getNickname(),
-                                "profileImageUrl", user.getProfileImageUrl(),
-                                "createdAt", user.getCreatedAt()
-                        )
-                )));
+                .map(user -> {
+                    UserResponseDTO userResponse = UserResponseDTO.from(user);
+                    return ResponseEntity.ok(Map.of(
+                            "code", 200,
+                            "message", "사용자 정보 조회 성공",
+                            "data", userResponse
+                    ));
+                });
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/UserResponseDTO.java
@@ -1,0 +1,24 @@
+package art.snail.naillian.backend.domain.user.dto;
+
+import art.snail.naillian.backend.domain.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDTO {
+    private Integer userId;
+    private String nickname;
+    private String profileImageUrl;
+    private LocalDateTime createdAt;
+
+    public static UserResponseDTO from(User user){
+        return UserResponseDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/SocialLogin.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/SocialLogin.java
@@ -1,0 +1,21 @@
+package art.snail.naillian.backend.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table("social_login")
+public class SocialLogin {
+    @Id
+    private Integer id;
+    private Integer userId;
+    private String platform; // KAKAO
+    private String platformUserId;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/User.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/User.java
@@ -1,0 +1,30 @@
+package art.snail.naillian.backend.domain.user.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+@Table("user")
+public class User {
+    @Id
+    private Integer id;
+    private String nickname;
+    private String userType;
+    private String profileImageUrl;
+    private String registeredIp;
+
+    @Column("created_at")
+    private LocalDateTime createdAt;
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/User.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/User.java
@@ -19,12 +19,9 @@ public class User {
     @Id
     private Integer id;
     private String nickname;
-    private String userType;
+    private UserType userType;
     private String profileImageUrl;
     private String registeredIp;
-
-    @Column("created_at")
     private LocalDateTime createdAt;
-    @Column("deleted_at")
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/UserType.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/UserType.java
@@ -1,0 +1,6 @@
+package art.snail.naillian.backend.domain.user.entity;
+
+public enum UserType {
+    CUSTOMER,
+    STORE
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/SocialLoginRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/SocialLoginRepository.java
@@ -1,0 +1,10 @@
+package art.snail.naillian.backend.domain.user.repository;
+
+import art.snail.naillian.backend.domain.user.entity.SocialLogin;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+
+public interface SocialLoginRepository extends ReactiveCrudRepository<SocialLogin, Integer> {
+    Mono<SocialLogin> findByPlatformUserId(String platformUserId);
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package art.snail.naillian.backend.domain.user.repository;
+
+import art.snail.naillian.backend.domain.user.entity.User;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface UserRepository extends ReactiveCrudRepository<User, Integer> {
+    Mono<User> findByNickname(String nickname);
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -1,0 +1,42 @@
+package art.snail.naillian.backend.domain.user.service;
+
+import art.snail.naillian.backend.domain.auth.service.AuthenticationService;
+import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
+import art.snail.naillian.backend.domain.user.entity.User;
+import art.snail.naillian.backend.domain.user.repository.UserRepository;
+import art.snail.naillian.backend.errors.ReportableError;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final AuthenticationService authenticationService;
+
+    public Mono<UserResponseDTO> getUserInfo(String token) {
+        return authenticationService.extractUserIdFromToken(token)
+                .flatMap(userRepository::findById)
+                .map(UserResponseDTO::from)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.", 404)));
+    }
+
+    /** 1. 사용자 저장 */
+    public Mono<User> save(User user) {
+        return userRepository.save(user);
+    }
+
+    /** 2. 사용자 삭제(논리 삭제)*/
+    public Mono<Void> deleteUser(Integer userId) {
+        return userRepository.findById(userId)
+                .flatMap(user -> {
+                    user.setDeletedAt(LocalDateTime.now()); // 논리 삭제 (deletedAt 설정)
+                    return userRepository.save(user);
+                })
+                .then();
+    }
+}


### PR DESCRIPTION
### 🔖 관련 티켓
SN-8 ([Jira 링크](https://crusia.atlassian.net/browse/SN-8))

<br>

### 📌 작업 개요 
- 카카오 로그인(OAuth2) 기능 구현
### ✅ 작업 항목
- /auth/kakao/login
-  → 카카오 로그인 URL 리다이렉션
- /auth/kakao/callback
-  → 인가 코드 받아 액세스 토큰 요청

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. /auth/kakao/login → 카카오 로그인 URL 리다이렉션, /auth/kakao/callback → 인가 코드 받아 액세스 토큰 요청