### PR TITLE
[FEAT] 공통 응답부 생성

### DIFF
--- a/src/main/java/art/snail/naillian/backend/common/CommonResponse.java
+++ b/src/main/java/art/snail/naillian/backend/common/CommonResponse.java
@@ -1,0 +1,52 @@
+package art.snail.naillian.backend.common;
+
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Builder;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.lang.NonNull;
+
+import java.io.IOException;
+
+
+@Builder
+@JsonSerialize(using = CommonResponse.Serializer.class)
+public class CommonResponse<T> {
+    @Builder.Default
+    private int code = 200;
+
+    @Builder.Default
+    private String msg = "";
+
+    @Builder.Default
+    private T data = null;
+
+    public static <T> @NonNull CommonResponse<T> success(T data) {
+        return CommonResponse.<T>builder()
+                .data(data)
+                .build();
+    }
+
+    public static @NonNull CommonResponse<?> fail(HttpStatusCode code, String message) {
+        return CommonResponse.builder()
+                .code(code.value())
+                .msg(message)
+                .build();
+    }
+
+    @JsonComponent
+    static class Serializer extends JsonSerializer<CommonResponse<?>> {
+        @Override
+        public void serialize(CommonResponse<?> response, JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
+            gen.writeStartObject();
+            gen.writeNumberField("code", response.code);
+            gen.writeStringField("message", response.msg);
+            gen.writeObjectField("data", response.data);
+            gen.writeEndObject();
+        }
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/common/PageDTO.java
+++ b/src/main/java/art/snail/naillian/backend/common/PageDTO.java
@@ -31,13 +31,9 @@ public class PageDTO<T> extends PageImpl<T> {
 
             gen.writeFieldName("content");
             gen.writeStartArray();
-            page.getContent().forEach(content -> {
-                try {
-                    gen.writeObject(content);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
+            for (Object content : page.getContent()) {
+                gen.writeObject(content);
+            }
             gen.writeEndArray();
 
             gen.writeEndObject();

--- a/src/main/java/art/snail/naillian/backend/common/PageDTO.java
+++ b/src/main/java/art/snail/naillian/backend/common/PageDTO.java
@@ -1,0 +1,46 @@
+package art.snail.naillian.backend.common;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.io.IOException;
+import java.util.List;
+
+@JsonSerialize(using = PageDTO.Serializer.class)
+public class PageDTO<T> extends PageImpl<T> {
+    public PageDTO(List<T> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+
+    @JsonComponent
+    @SuppressWarnings("unchecked")
+    static class Serializer extends JsonSerializer<PageDTO<?>> {
+        @Override
+        public void serialize(PageDTO page, JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
+            gen.writeStartObject();
+
+            gen.writeNumberField("page", page.getNumber());
+            gen.writeNumberField("size", page.getSize());
+            gen.writeNumberField("totalElements", page.getTotalElements());
+            gen.writeNumberField("totalPages", page.getTotalPages());
+
+            gen.writeFieldName("content");
+            gen.writeStartArray();
+            page.getContent().forEach(content -> {
+                try {
+                    gen.writeObject(content);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            gen.writeEndArray();
+
+            gen.writeEndObject();
+        }
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/config/WebFluxConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/WebFluxConfig.java
@@ -1,0 +1,14 @@
+package art.snail.naillian.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.ReactivePageableHandlerMethodArgumentResolver;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.result.method.annotation.ArgumentResolverConfigurer;
+
+@Configuration
+public class WebFluxConfig implements WebFluxConfigurer {
+    @Override
+    public void configureArgumentResolvers(ArgumentResolverConfigurer configurer) {
+        configurer.addCustomResolver(new ReactivePageableHandlerMethodArgumentResolver());
+    }
+}


### PR DESCRIPTION
### 🔖 관련 티켓
SN-27 ([Jira 링크](https://crusia.atlassian.net/browse/SN-27))

<br>

### 📌 작업 개요
프로젝트 전체에서 사용할 공통 응답 엔티티 생성에 관한 건.

<br/>

### ✅ 작업 항목
- CommonResponse 를 통해 code, message, data 를 모두 래핑
- Pagination 도 래핑

<br>

### 📝 추가 설명
Pagination 을 지원하는 엔드포인트인 경우에는 Controller 의 핸들러가 인자로 `Pageable page` 를 포함해야 합니다. 포함하는 경우 Spring 이 pagination 에 들어가는 각 인자들을 자동으로 파싱하여 Pageable 객체로 만들어 줍니다.




