### PR TITLE
[FIX] pagination 응답 구조를 프론트와 맞추기

### DIFF
--- a/src/main/java/art/snail/naillian/backend/common/PageDTO.java
+++ b/src/main/java/art/snail/naillian/backend/common/PageDTO.java
@@ -29,7 +29,6 @@ public class PageDTO<T> extends PageImpl<T> {
                 gen.writeFieldName("pageInfo");
                 gen.writeStartObject();
                 gen.writeNumberField("currentPage", page.getNumber());
-                gen.writeNumberField("size", page.getSize());
                 gen.writeNumberField("totalElements", page.getTotalElements());
                 gen.writeNumberField("totalPages", page.getTotalPages());
                 gen.writeEndObject();

--- a/src/main/java/art/snail/naillian/backend/common/PageDTO.java
+++ b/src/main/java/art/snail/naillian/backend/common/PageDTO.java
@@ -24,17 +24,26 @@ public class PageDTO<T> extends PageImpl<T> {
         public void serialize(PageDTO page, JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
             gen.writeStartObject();
 
-            gen.writeNumberField("page", page.getNumber());
-            gen.writeNumberField("size", page.getSize());
-            gen.writeNumberField("totalElements", page.getTotalElements());
-            gen.writeNumberField("totalPages", page.getTotalPages());
-
-            gen.writeFieldName("content");
-            gen.writeStartArray();
-            for (Object content : page.getContent()) {
-                gen.writeObject(content);
+            // pageInfo
+            {
+                gen.writeFieldName("pageInfo");
+                gen.writeStartObject();
+                gen.writeNumberField("currentPage", page.getNumber());
+                gen.writeNumberField("size", page.getSize());
+                gen.writeNumberField("totalElements", page.getTotalElements());
+                gen.writeNumberField("totalPages", page.getTotalPages());
+                gen.writeEndObject();
             }
-            gen.writeEndArray();
+
+            // content[]
+            {
+                gen.writeFieldName("content");
+                gen.writeStartArray();
+                for (Object content : page.getContent()) {
+                    gen.writeObject(content);
+                }
+                gen.writeEndArray();
+            }
 
             gen.writeEndObject();
         }

--- a/src/main/java/art/snail/naillian/backend/domain/nail/controller/NaiLController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/controller/NaiLController.java
@@ -1,0 +1,23 @@
+package art.snail.naillian.backend.domain.nail;
+
+import art.snail.naillian.backend.common.CommonResponse;
+import art.snail.naillian.backend.common.PageDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+@RestController
+@RequestMapping("/nails")
+public class NaiLController {
+    @GetMapping("/")
+    public Mono<CommonResponse<Object>> getNails(Pageable page) {
+        return Flux.empty()
+                .collectList()
+                .map(list -> new PageDTO<>(list, page, list.size()))
+                .map(CommonResponse::success);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/nail/repository/NailAssetRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/repository/NailAssetRepository.java
@@ -1,0 +1,2 @@
+package art.snail.naillian.backend.domain.nail.repository;public class NailAssetRepository {
+}

--- a/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
@@ -1,0 +1,7 @@
+package art.snail.naillian.backend.domain.nail.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class NailService {
+}


### PR DESCRIPTION
### 🔖 관련 티켓
SN-31 ([Jira 링크](https://crusia.atlassian.net/browse/SN-31))

<br>

### 📌 작업 개요 
pageInfo 부분의 응답을 요청에 맞게 수정헀습니다

TO-BE
```json
{
  "code": 200,
  "message": "",
  "data": {
    "pageInfo": {
      "currentPage": 0,
      "size": 20,
      "totalElements": 0,
      "totalPages": 0
    },
    "content": []
  }
}
```

