### PR TITLE
hotfix: User entity 를 DDL 에 맞도록 수정

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/User.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/User.java
@@ -1,12 +1,15 @@
 package art.snail.naillian.backend.domain.user.entity;
 
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -19,14 +22,20 @@ public class User {
     private Integer id;
     private String nickname;
     private UserType userType;
-    private String profileImageUrl;
     private String registeredIp;
     private LocalDateTime createdAt;
     private LocalDateTime deletedAt;
-    private Integer onboardingStage;
+
     // 각 스텝을 완료했는지 저장할 수 있는 비트마스크
     /** 닉네임만 완료한 경우 0x01
      * 닉네임 + 취향선택 완료 0x01 | 0x02 = 0x03
      */
     private int onboardingStepsBitmask;
+
+    private static final Logger log = LoggerFactory.getLogger(User.class);
+
+    public String getProfileImageUrl() {
+        log.warn("User.profileImageUrl 은 현재 스키마에 존재하지 않아 항상 빈 값을 반환합니다.");
+        return "";
+    }
 }


### PR DESCRIPTION
### 📝 설명
필요 없는 두 필드: `profileImageUrl` 과 `onboardingStage` 를 삭제했습니다.

참조가 있던 `User.getProfileImageUrl()` 은 경고와 함께 살려뒀습니다.
