### PR TITLE
[FEAT] Spring Security 기반 권한 관리

### DIFF
--- a/src/main/java/art/snail/naillian/backend/common/CommonResponse.java
+++ b/src/main/java/art/snail/naillian/backend/common/CommonResponse.java
@@ -26,8 +26,13 @@ public class CommonResponse<T> {
     private T data = null;
 
     public static <T> @NonNull CommonResponse<T> success(T data) {
+        return success(data, "");
+    }
+
+    public static <T> @NonNull CommonResponse<T> success(T data, String message) {
         return CommonResponse.<T>builder()
                 .data(data)
+                .msg(message)
                 .build();
     }
 

--- a/src/main/java/art/snail/naillian/backend/config/AuthConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/AuthConfig.java
@@ -1,10 +1,15 @@
 package art.snail.naillian.backend.config;
 
+import art.snail.naillian.backend.domain.auth.jwt.JwtAuthFilter;
+import art.snail.naillian.backend.domain.auth.jwt.JwtProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -14,10 +19,21 @@ public class AuthConfig {
     };
 
     @Bean
-    SecurityWebFilterChain defaultSecurityFilterChain(ServerHttpSecurity http) throws Exception {
+    SecurityWebFilterChain defaultSecurityFilterChain(
+            ServerHttpSecurity http,
+            JwtProvider jwtProvider
+    ) throws Exception {
         return http
-                .authorizeExchange(exchange -> exchange.anyExchange().permitAll())
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)  //
+                .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())  // stateless authentication
+                .authorizeExchange(exchange -> exchange
+                        .pathMatchers(HttpMethod.OPTIONS).permitAll()
+                        .pathMatchers("/auth/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .addFilterAt(new JwtAuthFilter(jwtProvider), SecurityWebFiltersOrder.HTTP_BASIC)
                 .build();
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
@@ -1,0 +1,42 @@
+package art.snail.naillian.backend.domain.auth.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter implements WebFilter {
+    private final JwtProvider jwtProvider;
+
+    private static Mono<String> extractToken(ServerWebExchange exchange) {
+        return Mono.justOrEmpty(exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    private static Mono<String> extractTokenFromHeader(String headerValue) {
+        if (headerValue == null) return null;
+
+        int index = headerValue.indexOf(" ");
+        if (index == -1) return null;
+
+        return Mono.just(headerValue.substring(index + 1));
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return Mono.justOrEmpty(exchange)
+                .flatMap(JwtAuthFilter::extractToken)
+                .flatMap(JwtAuthFilter::extractTokenFromHeader)
+                .filter(Objects::nonNull)
+                .flatMap(jwtProvider::authUserByToken)
+                .flatMap(payload -> chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload)));
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
@@ -22,10 +22,10 @@ public class JwtAuthFilter implements WebFilter {
     }
 
     private static Mono<String> extractTokenFromHeader(String headerValue) {
-        if (headerValue == null) return null;
+        if (headerValue == null) return Mono.empty();
 
         int index = headerValue.indexOf(" ");
-        if (index == -1) return null;
+        if (index == -1) return Mono.empty();
 
         return Mono.just(headerValue.substring(index + 1));
     }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
@@ -9,8 +9,6 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
-import java.util.Objects;
-
 
 @Component
 @RequiredArgsConstructor
@@ -31,12 +29,13 @@ public class JwtAuthFilter implements WebFilter {
     }
 
     @Override
+    @SuppressWarnings("all")
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         return Mono.justOrEmpty(exchange)
                 .flatMap(JwtAuthFilter::extractToken)
                 .flatMap(JwtAuthFilter::extractTokenFromHeader)
-                .filter(Objects::nonNull)
                 .flatMap(jwtProvider::authUserByToken)
-                .flatMap(payload -> chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload)));
+                .flatMap(payload -> chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload)))
+                .switchIfEmpty(chain.filter(exchange));
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
@@ -72,7 +72,8 @@ public class JwtProvider {
 
     public Mono<UserAuthByTokenPayload> authUserByToken(String token) {
         return getUserIdFromToken(token)
-                .map(userId -> new UserAuthByTokenPayload(userId, "accessToken", token));
+                .map(userId -> new UserAuthByTokenPayload(userId, "accessToken", token))
+                .doOnNext(payload -> payload.setAuthenticated(true));
     }
 
 }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtProvider.java
@@ -5,14 +5,15 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import io.micrometer.common.lang.Nullable;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
-import java.util.UUID;
-import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtProvider {
@@ -67,6 +68,11 @@ public class JwtProvider {
                     return Integer.parseInt(userIdStr);
                 })
                 .onErrorMap(e -> new ReportableError(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다.", 401));
+    }
+
+    public Mono<UserAuthByTokenPayload> authUserByToken(String token) {
+        return getUserIdFromToken(token)
+                .map(userId -> new UserAuthByTokenPayload(userId, "accessToken", token));
     }
 
 }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/UserAuthByTokenPayload.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/UserAuthByTokenPayload.java
@@ -14,7 +14,6 @@ public class UserAuthByTokenPayload extends AbstractAuthenticationToken {
         this.userId = userId;
         this.tokenType = tokenType;
         this.accessToken = accessToken;
-        super.setAuthenticated(true);
     }
 
     @Override

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/UserAuthByTokenPayload.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/UserAuthByTokenPayload.java
@@ -1,0 +1,29 @@
+package art.snail.naillian.backend.domain.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+@Getter
+public class UserAuthByTokenPayload extends AbstractAuthenticationToken {
+    private final Integer userId;
+    private final String tokenType;
+    private final String accessToken;
+
+    public UserAuthByTokenPayload(Integer userId, String tokenType, String accessToken) {
+        super(null);
+        this.userId = userId;
+        this.tokenType = tokenType;
+        this.accessToken = accessToken;
+        super.setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.tokenType;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.userId;
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/auth/service/AuthenticationService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/service/AuthenticationService.java
@@ -24,9 +24,8 @@ public class AuthenticationService {
 
 
     /** Access Token 검증 및 사용자 ID 추출 */
-    public Mono<Integer> extractUserIdFromToken(String authorizationHeader) {
-        return Mono.justOrEmpty(authorizationHeader)
-                .map(this::parseToken)
+    public Mono<Integer> extractUserIdFromToken(String accessToken) {
+        return Mono.justOrEmpty(accessToken)
                 .flatMap(jwtProvider::getUserIdFromToken)
                 .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.UNAUTHORIZED ,"유효하지 않은 인증 정보입니다.")));
     }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/utils/AuthUtil.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/utils/AuthUtil.java
@@ -1,0 +1,14 @@
+package art.snail.naillian.backend.domain.auth.utils;
+
+import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import reactor.core.publisher.Mono;
+
+public class AuthUtil {
+    public static Mono<UserAuthByTokenPayload> getContextUser(Mono<SecurityContext> ctx) {
+        return ctx.map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .cast(UserAuthByTokenPayload.class);
+    }
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -1,9 +1,15 @@
 package art.snail.naillian.backend.domain.user.controller;
 
 
+import art.snail.naillian.backend.common.CommonResponse;
+import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
+import art.snail.naillian.backend.domain.auth.utils.AuthUtil;
+import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
 import art.snail.naillian.backend.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -14,20 +20,26 @@ import java.util.Map;
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;
+    private final Mono<SecurityContext> ctx = ReactiveSecurityContextHolder.getContext();
 
     /** 사용자 조회 */
     @GetMapping("/me")
-    public Mono<ResponseEntity<Map<String, Object>>> getUserInfo(@RequestHeader("Authorization") String accessToken) {
-        return userService.getUserInfo(accessToken);
+    public Mono<CommonResponse<UserResponseDTO>> getUserInfo() {
+        return AuthUtil.getContextUser(ctx)
+                .map(UserAuthByTokenPayload::getUserId)
+                .flatMap(userService::getUserById)
+                .map(UserResponseDTO::from)
+                .map(dto -> CommonResponse.success(dto, "사용자 정보 조회 성공"));
     }
 
     /** 닉네임 변경 (온보딩 여부 반영) */
     @PatchMapping("/me/nickname")
     public Mono<ResponseEntity<Map<String ,Object>>> updateNickname(
-            @RequestHeader("Authorization") String accessToken,
             @RequestBody Map<String, String> requestBody
     ) {
-        return userService.updateNickname(accessToken, requestBody.get("nickname"))
+        return AuthUtil.getContextUser(ctx)
+                .map(UserAuthByTokenPayload::getUserId)
+                .flatMap(userId -> userService.updateNickname(userId, requestBody.get("nickname")))
                 .map(ResponseEntity::ok);
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -2,22 +2,19 @@ package art.snail.naillian.backend.domain.user.service;
 
 import art.snail.naillian.backend.domain.auth.service.AuthenticationService;
 import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
-import art.snail.naillian.backend.domain.user.entity.SocialLogin;
 import art.snail.naillian.backend.domain.user.entity.User;
-import art.snail.naillian.backend.domain.user.entity.UserType;
-import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import art.snail.naillian.backend.errors.ReportableError;
-import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -28,9 +25,11 @@ public class UserService {
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 
-    private static  final int ONBOARDING_NICKNAME_FLAG = 0x01;
+    private static final int ONBOARDING_NICKNAME_FLAG = 0x01;
 
-    /** 기존 회원 정보 불러오기 */
+    /**
+     * 기존 회원 정보 불러오기
+     */
     public Mono<ResponseEntity<Map<String, Object>>> getUserInfo(String token) {
         return authenticationService.extractUserIdFromToken(token)
                 .flatMap(userRepository::findById)
@@ -55,12 +54,16 @@ public class UserService {
                 .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")));
     }
 
+    public Mono<User> getUserById(int id) {
+        return userRepository.findById(id)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")));
+    }
 
 
     /**
      * 닉네임 변경 (온보딩 여부에 따라 처리)
      */
-    public Mono<Map<String, Object>> updateNickname(String token, String newNickname) {
+    public Mono<Map<String, Object>> updateNickname(int userId, String newNickname) {
         if (newNickname == null || newNickname.isBlank()) {
             return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "닉네임을 입력해주세요."));
         }
@@ -68,27 +71,25 @@ public class UserService {
             return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자만 사용 가능하며 2~8자로 입력해야 합니다."));
         }
 
-        return authenticationService.extractUserIdFromToken(token)
-                .flatMap(userId -> userRepository.findById(userId)
-                        .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.")))
-                        .flatMap(user -> {
-                            boolean isOnboarding = (user.getNickname() == null || user.getNickname().isBlank());
+        return getUserById(userId)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.")))
+                .flatMap(user -> {
+                    boolean isOnboarding = (user.getNickname() == null || user.getNickname().isBlank());
 
-                            user.setNickname(newNickname);
-                            if (isOnboarding && (user.getOnboardingStepsBitmask() & ONBOARDING_NICKNAME_FLAG) == 0) {
-                                user.setOnboardingStepsBitmask(user.getOnboardingStepsBitmask() | ONBOARDING_NICKNAME_FLAG);
-                            }
+                    user.setNickname(newNickname);
+                    if (isOnboarding && (user.getOnboardingStepsBitmask() & ONBOARDING_NICKNAME_FLAG) == 0) {
+                        user.setOnboardingStepsBitmask(user.getOnboardingStepsBitmask() | ONBOARDING_NICKNAME_FLAG);
+                    }
 
-                            return userRepository.save(user)
-                                    .map(updatedUser -> createResponse(updatedUser, isOnboarding));
-                        })
-                );
+                    return userRepository.save(user)
+                            .map(updatedUser -> createResponse(updatedUser, isOnboarding));
+                });
     }
 
     /**
      * 변경 후 공통 응답
      */
-    private Map<String, Object> createResponse(User user, boolean isOnboarding){
+    private Map<String, Object> createResponse(User user, boolean isOnboarding) {
         return Map.of(
                 "code", 200,
                 "message", isOnboarding ? "닉네임이 성공적으로 저장되었습니다. (온보딩 완료)" : "닉네임이 변경 되었습니다.",
@@ -102,12 +103,16 @@ public class UserService {
     }
 
     /** 참고하려고 임시로 만들어둔 로직입니다. */
-    /** 사용자 저장 */
+    /**
+     * 사용자 저장
+     */
     public Mono<User> save(User user) {
         return userRepository.save(user);
     }
 
-    /** 사용자 삭제(논리 삭제)*/
+    /**
+     * 사용자 삭제(논리 삭제)
+     */
     public Mono<Void> deleteUser(Integer userId) {
         return userRepository.findById(userId)
                 .flatMap(user -> {


### PR DESCRIPTION
### 🔖 관련 티켓
SN-37 ([Jira 링크](https://crusia.atlassian.net/browse/SN-37))
<br>

### 📌 작업 개요 
<br/>


### ✅ 작업 항목 
1. WebFilter를 통한 jwt 인증 헤더 처리
2. SecurityContext를 이용한 유저 인증으로 리팩토링

<br />

### 📝 추가 설명
이제부터 `/auth/**` 를 제외한 모든 엔드포인트가 user의 accessToken으로 보호됩니다. 만약 특정 엔드포인트에 대한 보호 처리를 수정하고자 하는 경우에는`config/AuthConfig.java` 를 참고해주시기 바랍니다.

이제부터 모든 Controller/Handler는 SecurityContext를 통해서 토큰으로 이미 인증된 이용자 정보를 받을 수 있습니다. 이용자의 id와 accessToken을 전달하기 위한 `UserAuthByTokenPayload` class를 생성했으므로 확인 바랍니다. controller/handler에서 이 데이터를 받는 예제는 다음과 같습니다.

```java
import art.snail.naillian.backend.common.CommonResponse;
import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
import art.snail.naillian.backend.domain.auth.utils.AuthUtil;
import org.springframework.security.core.context.ReactiveSecurityContextHolder;
import org.springframework.security.core.context.SecurityContext;

@RestController
@RequestMapping("/foo")
@RequiredArgsConstructor
public class FooHandler {
    private final UserService userService;
    private final Mono<SecurityContext> ctx = ReactiveSecurityContextHolder.getContext();

    @GetMapping("/some-protected-endpoint")
    public Mono<CommonResponse<String>> someProtectedEndpoint() {
        return AuthUtil.getContextUser(ctx)
                .map(UserAuthByTokenPayload::getUserId)
                .flatMap(userService::getUserById)
                .map(user -> CommonResponse.success(user.getNickname() + "님 환영합니다!"));
    }
}
```

