### PR TITLE
refactor/omakase 오마카세로 변경한 구조 제안

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/controller/OnboardingController.java
@@ -2,9 +2,9 @@ package art.snail.naillian.backend.domain.onboarding.controller;
 
 import art.snail.naillian.backend.common.CommonResponse;
 import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
+import art.snail.naillian.backend.domain.onboarding.dto.OnboardingStepDTO;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,13 +20,14 @@ public class OnboardingController {
     private final OnboardingService onboardingService;
 
     @GetMapping("/onboarding-status")
-    public Mono<ResponseEntity<CommonResponse<String>>> getOnboardingStatus(
+    public Mono<CommonResponse<OnboardingStepDTO>> getOnboardingStatus(
             @RequestParam(name = "maxSupportedVersion", required = false, defaultValue = "1") int maxSupportedVersion
     ) {
         return ReactiveSecurityContextHolder.getContext()
                 .map(securityContext -> (UserAuthByTokenPayload) securityContext.getAuthentication())
                 .map(UserAuthByTokenPayload::getUserId)
                 .flatMap(userId -> onboardingService.getNextOnboardingStep(userId, maxSupportedVersion))
-                .map(ResponseEntity::ok);
+                .map(OnboardingStepDTO::new)
+                .map(CommonResponse::success);
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/dto/OnboardingStepDTO.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/dto/OnboardingStepDTO.java
@@ -1,0 +1,13 @@
+package art.snail.naillian.backend.domain.onboarding.dto;
+
+import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+@AllArgsConstructor
+public class OnboardingStepDTO {
+    private OnboardingStep nextOnboardingStep;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/entity/OnboardingStep.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/entity/OnboardingStep.java
@@ -1,8 +1,16 @@
 package art.snail.naillian.backend.domain.onboarding.entity;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
 
+import java.io.IOException;
+
 @Getter
+@JsonSerialize(using = OnboardingStep.OnboardingStepSerializer.class)
 public enum OnboardingStep {
     NICKNAME(0, 1),
     PREFERENCES(1, 2),
@@ -14,5 +22,17 @@ public enum OnboardingStep {
     OnboardingStep(int order, int requiredVersion) {
         this.bitmask = 1 << order;
         this.requiredVersion = requiredVersion;
+    }
+
+    public String getSerializeName() {
+        return "Onboarding" +
+                PropertyNamingStrategies.UpperCamelCaseStrategy.INSTANCE.translate(name().toLowerCase());
+    }
+
+    public static class OnboardingStepSerializer extends JsonSerializer<OnboardingStep> {
+        @Override
+        public void serialize(OnboardingStep step, JsonGenerator generator, SerializerProvider provider) throws IOException {
+            generator.writeObject(step.getSerializeName());
+        }
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/entity/OnboardingStep.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/entity/OnboardingStep.java
@@ -19,6 +19,16 @@ public enum OnboardingStep {
     private final int bitmask;
     private final int requiredVersion;
 
+    public static final int ALL_STEP_BITS;
+
+    static {
+        int bit = 0;
+        for (OnboardingStep step : OnboardingStep.values()) {
+            bit |= step.bitmask;
+        }
+        ALL_STEP_BITS = bit;
+    }
+
     OnboardingStep(int order, int requiredVersion) {
         this.bitmask = 1 << order;
         this.requiredVersion = requiredVersion;

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/entity/OnboardingStep.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/entity/OnboardingStep.java
@@ -1,6 +1,18 @@
 package art.snail.naillian.backend.domain.onboarding.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum OnboardingStep {
-    OnboardingNickname,
-    OnboardingPreferences
+    NICKNAME(0, 1),
+    PREFERENCES(1, 2),
+    ;
+
+    private final int bitmask;
+    private final int requiredVersion;
+
+    OnboardingStep(int order, int requiredVersion) {
+        this.bitmask = 1 << order;
+        this.requiredVersion = requiredVersion;
+    }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
@@ -1,6 +1,5 @@
 package art.snail.naillian.backend.domain.onboarding.service;
 
-import art.snail.naillian.backend.common.CommonResponse;
 import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.user.entity.User;
 import art.snail.naillian.backend.domain.user.service.UserService;
@@ -14,28 +13,20 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class OnboardingService {
     private final UserService userService;
-
-    private static final int STEP_NICKNAME = 0x01;
-    private static final int STEP_PREFERENCES = 0x02;
-
     /**
      * 유저 ID를 받아 다음 온보딩 스텝 결정
      * DB에서 유저 조회
      * 비트마스크 분석 후 다음 스텝 결정
      */
-    public Mono<CommonResponse<String>> getNextOnboardingStep(int userId, int maxSupportedVersion) {
+    public Mono<OnboardingStep> getNextOnboardingStep(int userId, int maxSupportedVersion) {
         return userService.getUserById(userId)
-                .flatMap(user -> {
-                    OnboardingStep nextStep = calculateNextStep(user, maxSupportedVersion);
-                    return Mono.just(CommonResponse.success(nextStep.name()));
-                })
-                .switchIfEmpty(Mono.just(CommonResponse.fail(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.")));
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.")))
+                .map(user -> calculateNextStep(user, maxSupportedVersion));
     }
-
 
     private OnboardingStep calculateNextStep(User user, int maxSupportedVersion) {
         for (OnboardingStep step : OnboardingStep.values()) {
-            if (maxSupportedVersion >= step.getRequiredVersion() && need(user, step))
+            if (maxSupportedVersion >= step.getRequiredVersion() && needsOnboarding(user, step))
                 return step;
         }
 

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
@@ -42,7 +42,20 @@ public class OnboardingService {
         throw new ReportableError(HttpStatus.NO_CONTENT, "이미 모든 온보딩을 완료했습니다.");
     }
 
-    private boolean need(User user, OnboardingStep step) {
+    public boolean needsOnboarding(User user, OnboardingStep step) {
         return 0 == (user.getOnboardingStepsBitmask() & step.getBitmask());
+    }
+
+    /**
+     * User entity 의 bitmask 를 수정하고 수정했는지 여부를 반환합니다.
+     *
+     * @return 비트마스크를 변경한 경우 true, 원래 해당 온보딩을 진행해서 비트마스크에 변화가 없으면 false
+     */
+    public boolean markOnboardingComplete(User user, OnboardingStep step) {
+        if (!needsOnboarding(user, step))
+            return false;
+
+        user.setOnboardingStepsBitmask(user.getOnboardingStepsBitmask() | step.getBitmask());
+        return true;
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
@@ -34,20 +34,15 @@ public class OnboardingService {
 
 
     private OnboardingStep calculateNextStep(User user, int maxSupportedVersion) {
-        if (needsNickname(user) && maxSupportedVersion >= 1) {
-            return OnboardingStep.OnboardingNickname;
+        for (OnboardingStep step : OnboardingStep.values()) {
+            if (maxSupportedVersion >= step.getRequiredVersion() && need(user, step))
+                return step;
         }
-        if (needsPreferences(user) && maxSupportedVersion >= 2) {
-            return OnboardingStep.OnboardingPreferences;
-        }
+
         throw new ReportableError(HttpStatus.NO_CONTENT, "이미 모든 온보딩을 완료했습니다.");
     }
 
-    private boolean needsNickname(User user) {
-        return (user.getOnboardingStepsBitmask() & STEP_NICKNAME) == 0;
-    }
-
-    private boolean needsPreferences(User user) {
-        return (user.getOnboardingStepsBitmask() & STEP_PREFERENCES) == 0;
+    private boolean need(User user, OnboardingStep step) {
+        return 0 == (user.getOnboardingStepsBitmask() & step.getBitmask());
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/onboarding/service/OnboardingService.java
@@ -33,7 +33,7 @@ public class OnboardingService {
         throw new ReportableError(HttpStatus.NO_CONTENT, "이미 모든 온보딩을 완료했습니다.");
     }
 
-    public boolean needsOnboarding(User user, OnboardingStep step) {
+    public static boolean needsOnboarding(User user, OnboardingStep step) {
         return 0 == (user.getOnboardingStepsBitmask() & step.getBitmask());
     }
 
@@ -42,7 +42,7 @@ public class OnboardingService {
      *
      * @return 비트마스크를 변경한 경우 true, 원래 해당 온보딩을 진행해서 비트마스크에 변화가 없으면 false
      */
-    public boolean markOnboardingComplete(User user, OnboardingStep step) {
+    public static boolean markOnboardingComplete(User user, OnboardingStep step) {
         if (!needsOnboarding(user, step))
             return false;
 

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -2,13 +2,15 @@ package art.snail.naillian.backend.domain.user.controller;
 
 
 import art.snail.naillian.backend.common.CommonResponse;
+import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
+import art.snail.naillian.backend.domain.user.dto.UserChangeNicknameDTO;
 import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
 import art.snail.naillian.backend.domain.user.service.UserService;
+import art.snail.naillian.backend.errors.ReportableError;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
-
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,13 +20,26 @@ public class UserController {
 
     /** 사용자 조회 */
     @GetMapping("/me")
-    public Mono<CommonResponse<UserResponseDTO>> getUserInfo() {
-        return userService.getUserInfo();
+    public Mono<CommonResponse<UserResponseDTO>> getUserInfo(
+            UserAuthByTokenPayload payload
+    ) {
+        return userService.getUserById(payload.getUserId())
+                .map(UserResponseDTO::from)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")))
+                .map(userResponse -> CommonResponse.success(userResponse, "사용자 정보 조회 성공"));
     }
 
     /** 닉네임 변경 (온보딩 여부 반영) */
     @PatchMapping("/me/nickname")
-    public Mono<CommonResponse<UserResponseDTO>> updateNickname(@RequestBody Map<String, String> requestBody){
-        return userService.updateNickname(requestBody.get("nickname"));
+    public Mono<CommonResponse<UserResponseDTO>> updateNickname(
+            UserAuthByTokenPayload payload,
+            @RequestBody UserChangeNicknameDTO requestBody
+    ) {
+        return userService.updateNickname(payload.getUserId(), requestBody.getNickname())
+                .flatMap(tuple -> {
+                    UserResponseDTO dto = UserResponseDTO.from(tuple.getT1());
+                    String message = tuple.getT2();
+                    return Mono.just(CommonResponse.success(dto, message));
+                });
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/UserChangeNicknameDTO.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/UserChangeNicknameDTO.java
@@ -1,0 +1,8 @@
+package art.snail.naillian.backend.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserChangeNicknameDTO {
+    private String nickname;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/UserResponseDTO.java
@@ -1,7 +1,7 @@
 package art.snail.naillian.backend.domain.user.dto;
 
+import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.user.entity.User;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,7 +18,7 @@ public class UserResponseDTO {
                 user.getId(),
                 user.getNickname(),
                 user.getProfileImageUrl(),
-                user.getOnboardingStepsBitmask() == 0x03 ? 1 : 0
+                user.getOnboardingStepsBitmask() == OnboardingStep.ALL_STEP_BITS ? 1 : 0
         );
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-    private final OnboardingService onboardingService;
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -21,8 +21,6 @@ public class UserService {
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 
-    private static final int ONBOARDING_NICKNAME_FLAG = 0x01;
-
     /**
      * 기존 회원 정보 불러오기
      */

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -2,7 +2,8 @@ package art.snail.naillian.backend.domain.user.service;
 
 import art.snail.naillian.backend.common.CommonResponse;
 import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
-import art.snail.naillian.backend.domain.auth.service.AuthenticationService;
+import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
+import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
 import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
 import art.snail.naillian.backend.domain.user.entity.User;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
@@ -12,13 +13,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
 import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
     private final UserRepository userRepository;
+    private final OnboardingService onboardingService;
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 
@@ -68,11 +70,8 @@ public class UserService {
                                 .switchIfEmpty(Mono.just(user))
                 )
                 .flatMap(user -> {
-                    boolean isOnboarding = (user.getNickname() == null || user.getNickname().isBlank());
                     user.setNickname(newNickname);
-                    if (isOnboarding && (user.getOnboardingStepsBitmask() & ONBOARDING_NICKNAME_FLAG) == 0) {
-                        user.setOnboardingStepsBitmask(user.getOnboardingStepsBitmask() | ONBOARDING_NICKNAME_FLAG);
-                    }
+                    boolean isOnboarding = onboardingService.markOnboardingComplete(user, OnboardingStep.NICKNAME);
                     return userRepository.save(user)
                             .map(updatedUser -> {
                                 String message = isOnboarding

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -1,18 +1,15 @@
 package art.snail.naillian.backend.domain.user.service;
 
-import art.snail.naillian.backend.common.CommonResponse;
-import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
 import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
-import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
 import art.snail.naillian.backend.domain.user.entity.User;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import art.snail.naillian.backend.errors.ReportableError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 import java.util.regex.Pattern;
 
@@ -29,56 +26,41 @@ public class UserService {
     /**
      * 기존 회원 정보 불러오기
      */
-    public Mono<CommonResponse<UserResponseDTO>> getUserInfo() {
-        return ReactiveSecurityContextHolder.getContext()
-                .map(ctx -> (UserAuthByTokenPayload) ctx.getAuthentication())
-                .flatMap(userAuth -> userRepository.findById(userAuth.getUserId()))
-                .map(UserResponseDTO::from)
-                .map(userResponse -> CommonResponse.success(userResponse, "사용자 정보 조회 성공"))
-                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")));
-    }
-
     public Mono<User> getUserById(int id) {
-        return userRepository.findById(id)
-                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")));
+        return userRepository.findById(id);
     }
 
+    public Mono<User> getUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname);
+    }
 
     /**
      * 닉네임 변경 (온보딩 여부에 따라 처리)
      */
-    public Mono<CommonResponse<UserResponseDTO>> updateNickname(String newNickname) {
+    public Mono<Tuple2<User, String>> updateNickname(int userId, String newNickname) {
         if (newNickname == null || newNickname.isBlank()) {
             return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "닉네임을 입력해주세요."));
         }
         if (!NICKNAME_PATTERN.matcher(newNickname).matches()) {
             return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자만 사용 가능하며 2~8자로 입력해야 합니다."));
         }
-        return ReactiveSecurityContextHolder.getContext()
-                .map(ctx -> (UserAuthByTokenPayload) ctx.getAuthentication())
-                .flatMap(userAuth -> userRepository.findById(userAuth.getUserId()))
-                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.")))
-                .flatMap(user ->
-                        // 닉네임 중복 체크: 동일한 닉네임이 다른 사용자에게 이미 사용 중인지 확인
-                        userRepository.findByNickname(newNickname)
-                                .flatMap(existingUser -> {
-                                    if (existingUser.getId() != user.getId()) {
-                                        return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."));
-                                    }
-                                    return Mono.just(user);
-                                })
-                                .switchIfEmpty(Mono.just(user))
-                )
+
+        return Mono.just(newNickname)
+                .flatMap(this::getUserByNickname)
+                .flatMap(existingUser -> {
+                    if (existingUser.getId() != userId)
+                        return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."));
+                    return getUserById(userId)
+                            .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.")));
+                })
                 .flatMap(user -> {
                     user.setNickname(newNickname);
-                    boolean isOnboarding = onboardingService.markOnboardingComplete(user, OnboardingStep.NICKNAME);
+                    String message = onboardingService.markOnboardingComplete(user, OnboardingStep.NICKNAME)
+                            ? "닉네임이 성공적으로 저장되었습니다. (온보딩 완료)"
+                            : "닉네임이 변경되었습니다.";
+
                     return userRepository.save(user)
-                            .map(updatedUser -> {
-                                String message = isOnboarding
-                                        ? "닉네임이 성공적으로 저장되었습니다. (온보딩 완료)"
-                                        : "닉네임이 변경되었습니다.";
-                                return CommonResponse.success(UserResponseDTO.from(updatedUser), message);
-                            });
+                            .zipWith(Mono.just(message));
                 });
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -43,17 +43,24 @@ public class UserService {
             return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자만 사용 가능하며 2~8자로 입력해야 합니다."));
         }
 
-        return Mono.just(newNickname)
-                .flatMap(this::getUserByNickname)
-                .flatMap(existingUser -> {
-                    if (existingUser.getId() != userId)
+        return Mono.zip(
+                        this.getUserById(userId),
+                        this.getUserByNickname(newNickname)
+                                .map(Optional::of)
+                                .defaultIfEmpty(Optional.empty())
+                )
+                .flatMap(tuple -> {
+                    User user = tuple.getT1();
+                    Optional<User> existingUser = tuple.getT2();
+
+                    if (existingUser.isPresent() && existingUser.get().getId() != userId)
                         return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."));
-                    return getUserById(userId)
-                            .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.")));
+
+                    return Mono.just(user);
                 })
                 .flatMap(user -> {
                     user.setNickname(newNickname);
-                    String message = onboardingService.markOnboardingComplete(user, OnboardingStep.NICKNAME)
+                    String message = OnboardingService.markOnboardingComplete(user, OnboardingStep.NICKNAME)
                             ? "닉네임이 성공적으로 저장되었습니다. (온보딩 완료)"
                             : "닉네임이 변경되었습니다.";
 


### PR DESCRIPTION
### 📝 설명
오마카세로 수정해보았습니다.

1. View를 생성하는 것은 Controller에 위임
2. 여러 군데에 산개해있던 온보딩 관련 비트마스크를 enum에 병합시킴
4. 백엔드 개발에서 사용하는 ENUM은 상수임을 알 수 있도록 모두 대문자로 표기
    - 직렬화 시 사용하는 이름을 별도로 지정 가능하도록 변경
5. Reactive 컨벤션에 맞도록 병렬로 처리할 수 있는 부분 개선
    - 닉네임 수정 시 현재 사용자를 가져오는 것과 바꾸고자 하는 닉네임을 이미 갖고 있는 사용자를 가져오는 것을 동시에 처리
