### PR TITLE
[BUG] 백엔드 엔드포인트가 2번 호출되는 문제

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
@@ -36,6 +36,7 @@ public class JwtAuthFilter implements WebFilter {
                 .flatMap(JwtAuthFilter::extractTokenFromHeader)
                 .flatMap(jwtProvider::authUserByToken)
                 .flatMap(payload -> chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload)))
-                .switchIfEmpty(chain.filter(exchange));
+                .switchIfEmpty(Mono.defer(() -> chain.filter(exchange).then(Mono.empty())))
+                ;
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
@@ -31,8 +31,7 @@ public class JwtAuthFilter implements WebFilter {
     @Override
     @SuppressWarnings("all")
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-        return Mono.justOrEmpty(exchange)
-                .flatMap(JwtAuthFilter::extractToken)
+        return extractToken(exchange)
                 .flatMap(JwtAuthFilter::extractTokenFromHeader)
                 .flatMap(jwtProvider::authUserByToken)
                 .flatMap(payload -> chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload)))


### PR DESCRIPTION
### 🔖 관련 티켓
SN-70 ([Jira 링크](https://crusia.atlassian.net/browse/SN-70))

<br>

### 📌 작업 개요 
이미 응답이 전송된 request 에 대해 재전송을 야기하는 문제

<br/>

### ✅ 작업 항목 
- WebFilter 구현의 switchIfEmpty 에서 value evaluation 이 lazy 하지 않은 문제로 추정

<br>



### 📝 추가 설명
앞선 체인이 정상적으로 실행된 후 `.switchIfEmpty(chain.filter(exchange))` 이 호출될 때 `chain.filter(exchange)` 가 값으로 평가되면서 실제로는 switch 가 일어나지 않음에도 chain이 실행되는 문제가 있었음. 

`Mono.defer(lambda)` 를 통해 해결

