### PR TITLE
hotfix: 핸들러가 두 번 호출되는 문제

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/art/snail/naillian/backend/domain/auth/jwt/JwtAuthFilter.java
@@ -34,8 +34,14 @@ public class JwtAuthFilter implements WebFilter {
         return extractToken(exchange)
                 .flatMap(JwtAuthFilter::extractTokenFromHeader)
                 .flatMap(jwtProvider::authUserByToken)
-                .flatMap(payload -> chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload)))
-                .switchIfEmpty(Mono.defer(() -> chain.filter(exchange).then(Mono.empty())))
+                .flatMap(payload -> chain.filter(exchange)
+                        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(payload))
+                        .then(Mono.just(true))
+                )
+                .switchIfEmpty(Mono.defer(() -> chain.filter(exchange))
+                        .then(Mono.just(false))
+                )
+                .then(Mono.empty())
                 ;
     }
 }


### PR DESCRIPTION
https://github.com/Snail-official/Nailian-BE/pull/36 의 후속입니다.

WebFilterChain이 하위의 여러 filter를 실행하는데, 순서에 따라 앞의 Mono가 empty로 끝나는 경우가 발생합니다. 이 경우 switchIfEmpty에 걸려서 chain이 두 번 실행되는 문제를 해결했습니다.