### PR TITLE
[REFACTOR] 네일 세트 저장 기능에 중복시 409 추가

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/nail/repository/NailSetRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/repository/NailSetRepository.java
@@ -14,4 +14,7 @@ public interface NailSetRepository extends ReactiveCrudRepository<NailSet, Integ
     Mono<Long> countByUploadedBy(int uploadedUserId);
 
     Mono<NailSet> findByUploadedByAndNailGroupId(int uploadedUserId, int groupId);
+
+    Mono<Boolean> existsByUploadedByAndNailGroupId(int uploadedBy, int groupId);
+
 }

--- a/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -179,22 +180,22 @@ public class NailService {
      * @param setId  네일 세트의 id, 유효성을 검증함
      * @return 새로 생성되거나 이미 보관했던 네일 세트 정보
      */
+    @Transactional
     public Mono<NailSet> cloneNailSetForUser(int userId, int setId) {
         return getNailSet(setId)
                 .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "해당 네일 세트를 찾을 수 없습니다.")))
-                .flatMap(originalSet ->
-                        // 존재 여부를 Boolean으로 조회하여 처리
-                        setRepository.existsByUploadedByAndNailGroupId(userId, originalSet.getNailGroupId())
-                                .flatMap(exists -> exists
-                                        ? Mono.error(new ReportableError(HttpStatus.CONFLICT, "이미 저장된 네일 세트입니다."))
-                                        : setRepository.save(NailSet.builder()
-                                        .nailGroupId(originalSet.getNailGroupId())
-                                        .uploadedBy(userId)
-                                        .build())
-                                )
-                );
+                .flatMap(originalSet -> setRepository.existsByUploadedByAndNailGroupId(userId, originalSet.getNailGroupId())
+                        .filter(exists -> !exists)
+                        .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.CONFLICT, "이미 저장된 네일 세트입니다.")))
+                        .then(Mono.just(originalSet))
+                )
+                .map(originalSet -> NailSet.builder()
+                        .nailGroupId(originalSet.getNailGroupId())
+                        .uploadedBy(userId)
+                        .build())
+                .flatMap(setRepository::save)
+                ;
     }
-
 
 
     public Mono<NailSet> deleteNailSetEnsureUser(int userId, int setId) {

--- a/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
@@ -183,15 +183,19 @@ public class NailService {
         return getNailSet(setId)
                 .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "해당 네일 세트를 찾을 수 없습니다.")))
                 .flatMap(originalSet ->
-                        // 이미 저장한 적 있는 경우 이미 저장된 정보를 제공함
-                        setRepository.findByUploadedByAndNailGroupId(userId, originalSet.getNailGroupId())
-                                // 저장한 적 없는 경우 새로 저장함
-                                .switchIfEmpty(setRepository.save(NailSet.builder()
+                        // 존재 여부를 Boolean으로 조회하여 처리
+                        setRepository.existsByUploadedByAndNailGroupId(userId, originalSet.getNailGroupId())
+                                .flatMap(exists -> exists
+                                        ? Mono.error(new ReportableError(HttpStatus.CONFLICT, "이미 저장된 네일 세트입니다."))
+                                        : setRepository.save(NailSet.builder()
                                         .nailGroupId(originalSet.getNailGroupId())
                                         .uploadedBy(userId)
-                                        .build()))
+                                        .build())
+                                )
                 );
     }
+
+
 
     public Mono<NailSet> deleteNailSetEnsureUser(int userId, int setId) {
         return getNailSet(setId)


### PR DESCRIPTION
### 🔖 관련 티켓
SN-108 ([Jira 링크](https://crusia.atlassian.net/browse/SN-108))

<br>

### 📌 작업 개요 
- 사용자가 네일 세트를 보관함에 저장시 겹치는 경우 409를 반환
- ### ✅ 작업 항목 
- 기존 Chain은 유지한 채 존재 여부만 확인하는 쿼리를 추가

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. 에서 직접 오류를 반환할 경우 제너릭 타입을 명시해줘야 하는 사항이 있었습니다.
2. 명시적으로 반환하는 대신 DB에서 전체 엔티티를 조회하는 것보다 존재 여부만 확인하는게 쿼리가 더 가볍고 빠르기 때문에 repository에  를 추가하였습니다.
3. 제너릭 타입을 명시적으로 지정할 경우 기존 코드 스타일과 어긋날 것 같아 해당 부분 고려하여 수정하였습니다.
