### PR TITLE
[FIX] /nails/에 random query param의 기본값을 true로 설정

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/nail/controller/NailController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/controller/NailController.java
@@ -30,13 +30,12 @@ public class NailController {
             UserAuthByTokenPayload payload,
             Pageable page
     ) {
-        if(random){
-            return nailService.getRandom(page, payload.getUserId())
-                    .map(CommonResponse::success);
-        } else {
-            return nailService.getNailTipsByAttributes(shape, color, category, page)
-                    .map(CommonResponse::success);
-        }
+        return Mono.just(random)
+                .flatMap(isRandom -> isRandom
+                        ? nailService.getRandom(page, payload.getUserId())
+                        : nailService.getNailTipsByAttributes(shape, color, category, page)
+                )
+                .map(CommonResponse::success);
     }
 
     @GetMapping("/preferences")

--- a/src/main/java/art/snail/naillian/backend/domain/nail/controller/NailController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/controller/NailController.java
@@ -26,10 +26,17 @@ public class NailController {
             @RequestParam(value = "shape", required = false) String shape,
             @RequestParam(value = "color", required = false) String color,
             @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "random", defaultValue = "true") boolean random,
+            UserAuthByTokenPayload payload,
             Pageable page
     ) {
-        return nailService.getNailTipsByAttributes(shape, color, category, page)
-                .map(CommonResponse::success);
+        if(random){
+            return nailService.getRandom(page, payload.getUserId())
+                    .map(CommonResponse::success);
+        } else {
+            return nailService.getNailTipsByAttributes(shape, color, category, page)
+                    .map(CommonResponse::success);
+        }
     }
 
     @GetMapping("/preferences")

--- a/src/main/java/art/snail/naillian/backend/domain/nail/repository/NailTipRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/repository/NailTipRepository.java
@@ -50,4 +50,13 @@ public interface NailTipRepository extends ReactiveCrudRepository<NailTip, Integ
             String color,
             String category
     );
+
+    @Query("""
+            SELECT *
+            FROM nail_tip
+            ORDER BY RAND(:seed)
+            LIMIT :#{#pageable.getPageSize()}
+            OFFSET :#{#pageable.getOffset()}
+            """)
+    Flux<NailTip> findAllShuffled(Pageable pageable, int seed);
 }

--- a/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/service/NailService.java
@@ -291,5 +291,14 @@ public class NailService {
                 .collectList();
     }
 
-
+    public Mono<PageDTO<NailIdAndUrlDTO>> getRandom(Pageable page, int userId) {
+        return tipRepository.count()
+                .filter(count -> count > 0)
+                .zipWith(tipRepository.findAllShuffled(page, userId)
+                        .map(NailIdAndUrlDTO::from)
+                        .collectList())
+                .map(tuple -> new PageDTO<>(tuple.getT2(), page, tuple.getT1()))
+                .switchIfEmpty(Mono.just(new PageDTO<>(Collections.emptyList(), page, 0)))
+                ;
+    }
 }


### PR DESCRIPTION
### 🔖 관련 티켓
SN-124 ([Jira 링크](https://crusia.atlassian.net/browse/SN-124))

<br>

### 📌 작업 개요
- 현재 온보딩 화면에서 불러오는 /nails/ 엔드포인트는 기존 필터링 로직이므로 random query param의 기본값을 true로 설정하여 온보딩 화면에서 randomization 적용 되도록 설정
- ### ✅ 작업 항목 
- /nails/ 엔드포인트에 randomization 추가
- query param의 기본값을 true로 설정하여 온보딩에서도 random을 적용할 수 있게 변경

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. 추가 설명 1
2. 추가 설명 2
3. and so on ...