### PR TITLE
[HOTFIX] /nails/?random 의 기본값을 false 로 변경

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/nail/controller/NailController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/nail/controller/NailController.java
@@ -26,7 +26,7 @@ public class NailController {
             @RequestParam(value = "shape", required = false) String shape,
             @RequestParam(value = "color", required = false) String color,
             @RequestParam(value = "category", required = false) String category,
-            @RequestParam(value = "random", defaultValue = "true") boolean random,
+            @RequestParam(value = "random", defaultValue = "false") boolean random,
             UserAuthByTokenPayload payload,
             Pageable page
     ) {


### PR DESCRIPTION
### 🔖 관련 티켓
SN-124 ([Jira 링크](https://crusia.atlassian.net/browse/SN-124))

<br>

### 📌 작업 개요
- 현재 온보딩 화면에서 불러오는 /nails/ 엔드포인트는 기존 필터링 로직이므로 random query param의 기본값을 true로 설정하여 온보딩 화면에서 randomization 적용 되도록 설정
- ### ✅ 작업 항목 
- /nails/ 엔드포인트에 randomization 추가
- query param의 기본값을 true로 설정하여 온보딩에서도 random을 적용할 수 있게 변경

<br>




### 📝 추가 설명
#56 에 이어 FE 에서의 use-case를 고려했을 때 기본값을 false 로 변경했습니다.

> Use cases
1.  으로 랜덤 순서로 섞인 네일 받기
2.  으로 순서가 섞이지 않고 필터되지 않은 네일 받기
3.  으로 순서가 섞이지 않고 필터된 네일 받기