### PR TITLE
[HOTFIX] 공개 라우트는 토큰 인증에서 제외

### DIFF
--- a/src/main/java/art/snail/naillian/backend/config/AuthConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/AuthConfig.java
@@ -29,6 +29,7 @@ public class AuthConfig {
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)  //
                 .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())  // stateless authentication
                 .authorizeExchange(exchange -> exchange
+                        .pathMatchers(PUBLIC_ROUTES).permitAll()
                         .pathMatchers(HttpMethod.OPTIONS).permitAll()
                         .pathMatchers("/auth/**").permitAll()
                         .pathMatchers("/model/**").permitAll()


### PR DESCRIPTION

### 📝 추가 설명
기존 라우팅 환경에서 공개 라우트도 토큰으로 보호되는 문제를 해결했습니다.

