### PR TITLE
[FEAT] 새로운 ci-cd 환경에 맞춘 배포 방식 반영

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -48,6 +48,6 @@ jobs:
       - build-and-push-docker
     steps:
       - name: Dispatch event
-        run: gh api /repos/snail-official/nailian-iac/dispatches -f event_type='restart-backend-dev'
+        run: gh api /repos/snail-official/nailian-iac/dispatches -f event_type='cd-backend' -f 'client_payload[commit_hash]=${{ needs.build-and-push-docker.outputs.SHORT_SHA }}'
         env:
           GH_TOKEN: ${{ secrets.GH_TRIGGER_TOKEN }}

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -48,6 +48,6 @@ jobs:
       - build-and-push-docker
     steps:
       - name: Dispatch event
-        run: gh api /repos/snail-official/nailian-iac/dispatches -f event_type='cd-backend' -f 'client_payload[commit_hash]=${{ needs.build-and-push-docker.outputs.SHORT_SHA }}'
+        run: gh api /repos/$GITHUB_REPOSITORY_OWNER/nailian-iac/dispatches -f event_type='cd-backend' -f 'client_payload[commit_hash]=${{ needs.build-and-push-docker.outputs.SHORT_SHA }}'
         env:
           GH_TOKEN: ${{ secrets.GH_TRIGGER_TOKEN }}

--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-push-docker:
     runs-on: ubuntu-latest
+    outputs:
+      SHORT_SHA: ${{ steps.sha.outputs.SHORT_SHA }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### 📝 추가 설명
helm chart 기반의 infra-as-a-code 로 전환하면서 Continuous Deployment 를 위해 commit hash 를 제공해야 함