### PR TITLE
[FEAT] 이벤트 모달 API

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -5,10 +5,7 @@ import art.snail.naillian.backend.common.CommonResponse;
 import art.snail.naillian.backend.domain.auth.jwt.UserAuthByTokenPayload;
 import art.snail.naillian.backend.domain.nail.dto.NailImageUrlDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailSetEmbedDTO;
-import art.snail.naillian.backend.domain.user.dto.CreateNailSetDTO;
-import art.snail.naillian.backend.domain.user.dto.UserChangeNicknameDTO;
-import art.snail.naillian.backend.domain.user.dto.UserResponseDTO;
-import art.snail.naillian.backend.domain.user.dto.UserScrapingNailSetIdDTO;
+import art.snail.naillian.backend.domain.user.dto.*;
 import art.snail.naillian.backend.domain.user.service.UserService;
 import art.snail.naillian.backend.errors.ReportableError;
 import lombok.RequiredArgsConstructor;
@@ -112,5 +109,17 @@ public class UserController {
     ) {
         return userService.unScrapNailSetForUser(payload.getUserId(), setId)
                 .then(Mono.just(CommonResponse.success(null, "네일 세트가 보관함에서 삭제되었습니다.")));
+    }
+
+    /**
+     * 사용자가 이벤트 응모
+     */
+    @PostMapping("/me/event")
+    public Mono<CommonResponse<Void>> submitEvent(
+            UserAuthByTokenPayload payload,
+            @RequestBody EventSubmissionDTO body){
+
+        return userService.submitEvent(payload.getUserId(), body)
+                .thenReturn(CommonResponse.success(null, "응모가 완료되었습니다."));
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -117,8 +117,8 @@ public class UserController {
     @PostMapping("/me/event")
     public Mono<CommonResponse<Void>> submitEvent(
             UserAuthByTokenPayload payload,
-            @RequestBody EventSubmissionDTO body){
-
+            @RequestBody EventSubmissionDTO body
+    ) {
         return userService.submitEvent(payload.getUserId(), body)
                 .thenReturn(CommonResponse.success(null, "응모가 완료되었습니다."));
     }

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/EventSubmissionDTO.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/EventSubmissionDTO.java
@@ -1,0 +1,10 @@
+package art.snail.naillian.backend.domain.user.dto;
+
+import lombok.Data;
+
+
+@Data
+public class EventSubmissionDTO {
+    private String userInfo;
+    private Integer nailSetId;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/EventSubmissionDTO.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/EventSubmissionDTO.java
@@ -1,9 +1,9 @@
 package art.snail.naillian.backend.domain.user.dto;
 
-import lombok.Data;
+import lombok.Getter;
 
 
-@Data
+@Getter
 public class EventSubmissionDTO {
     private String userInfo;
     private Integer nailSetId;

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/EventSubmission.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/EventSubmission.java
@@ -1,0 +1,29 @@
+package art.snail.naillian.backend.domain.user.entity;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table("event_submission")
+public class EventSubmission {
+    @Id
+    private Integer id;
+
+    private Integer userId;
+    private Integer nailSetId;
+
+    private String email;
+    private String phoneNumber;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/EventSubmissionRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/EventSubmissionRepository.java
@@ -1,0 +1,10 @@
+package art.snail.naillian.backend.domain.user.repository;
+
+import art.snail.naillian.backend.domain.user.entity.EventSubmission;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface EventSubmissionRepository extends ReactiveCrudRepository<EventSubmission, Integer> {
+
+    Mono<Boolean> existsByUserId(Integer userId);
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -175,7 +176,7 @@ public class UserService {
                             .nailSetId(event.getNailSetId())
                             .email(isEmail ? event.getUserInfo() : null)
                             .phoneNumber(isEmail ? null : event.getUserInfo())
-                            .createdAt(LocalDateTime.now())
+                            .createdAt(LocalDateTime.now(Clock.systemUTC()))
                             .build();
                 })
                 .flatMap(eventRepository::save)

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -163,14 +163,11 @@ public class UserService {
 
         return nailService.getNailSet(event.getNailSetId())
                 .filter(set -> Objects.equals(set.getUploadedBy(), userId))
-                .switchIfEmpty(Mono.error(new ReportableError(
-                        HttpStatus.NOT_FOUND, "네일 세트를 찾을 수 없습니다.")))
-
-                .then(eventRepository.existsByUserId(userId))
-                .filter(exists -> !exists)
-                .switchIfEmpty(Mono.error(new ReportableError(
-                        HttpStatus.BAD_REQUEST, "이미 응모하셨습니다.")))
-
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "네일 세트를 찾을 수 없습니다.")))
+                .zipWith(eventRepository.existsByUserId(userId)
+                        .filter(exists -> !exists)
+                        .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 응모하셨습니다.")))
+                )
                 .map(__ -> {
                     boolean isEmail = event.getUserInfo().contains("@");
                     return EventSubmission.builder()
@@ -181,7 +178,6 @@ public class UserService {
                             .createdAt(LocalDateTime.now())
                             .build();
                 })
-
                 .flatMap(eventRepository::save)
                 .then();
     }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ import art.snail.naillian.backend.common.PageDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailImageUrlDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailSetEmbedDTO;
 import art.snail.naillian.backend.domain.nail.entity.NailTip;
-import art.snail.naillian.backend.domain.nail.repository.NailTipRepository;
 import art.snail.naillian.backend.domain.nail.service.NailService;
 import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
@@ -27,17 +26,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final EventSubmissionRepository eventRepository;
-
-    private static final Pattern EMAIL_OR_PHONE =
-            Pattern.compile("(^[^@]+@[^@\\.]+\\.[^@\\.\\n]+$)|(^0[15-9][0-9]{1,2}-[0-9]{3,4}-[0-9]{3,5}$)");
-
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
+    private static final Pattern EMAIL_OR_PHONE = Pattern.compile("(^[^@]+@[^@.]+\\.[^@.\\n]+$)|(^0[15-9][0-9]{1,2}-[0-9]{3,4}-[0-9]{3,5}$)");
     private final NailService nailService;
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 
     /**
      * 기존 회원 정보 불러오기

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -4,10 +4,14 @@ import art.snail.naillian.backend.common.PageDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailImageUrlDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailSetEmbedDTO;
 import art.snail.naillian.backend.domain.nail.entity.NailTip;
+import art.snail.naillian.backend.domain.nail.repository.NailTipRepository;
 import art.snail.naillian.backend.domain.nail.service.NailService;
 import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
+import art.snail.naillian.backend.domain.user.dto.EventSubmissionDTO;
+import art.snail.naillian.backend.domain.user.entity.EventSubmission;
 import art.snail.naillian.backend.domain.user.entity.User;
+import art.snail.naillian.backend.domain.user.repository.EventSubmissionRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import art.snail.naillian.backend.errors.ReportableError;
 import lombok.RequiredArgsConstructor;
@@ -20,13 +24,17 @@ import reactor.util.function.Tuple2;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
-
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final EventSubmissionRepository eventRepository;
+
+    private static final Pattern EMAIL_OR_PHONE =
+            Pattern.compile("(^[^@]+@[^@\\.]+\\.[^@\\.\\n]+$)|(^0[15-9][0-9]{1,2}-[0-9]{3,4}-[0-9]{3,5}$)");
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
     private final NailService nailService;
@@ -144,6 +152,40 @@ public class UserService {
 
         return getUserById(userId)
                 .then(nailService.deleteNailSetEnsureUser(userId, nailSetId))
+                .then();
+    }
+
+    /**
+     * 아트 이벤트 응모
+     */
+    public Mono<Void> submitEvent(int userId, EventSubmissionDTO event) {
+        if (!EMAIL_OR_PHONE.matcher(event.getUserInfo()).matches()) {
+            return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST,
+                    "입력하신 이메일 혹은 전화번호가 올바르지 않습니다."));
+        }
+
+        return nailService.getNailSet(event.getNailSetId())
+                .filter(set -> Objects.equals(set.getUploadedBy(), userId))
+                .switchIfEmpty(Mono.error(new ReportableError(
+                        HttpStatus.NOT_FOUND, "네일 세트를 찾을 수 없습니다.")))
+
+                .then(eventRepository.existsByUserId(userId))
+                .filter(exists -> !exists)
+                .switchIfEmpty(Mono.error(new ReportableError(
+                        HttpStatus.BAD_REQUEST, "이미 응모하셨습니다.")))
+
+                .map(__ -> {
+                    boolean isEmail = event.getUserInfo().contains("@");
+                    return EventSubmission.builder()
+                            .userId(userId)
+                            .nailSetId(event.getNailSetId())
+                            .email(isEmail ? event.getUserInfo() : null)
+                            .phoneNumber(isEmail ? null : event.getUserInfo())
+                            .createdAt(LocalDateTime.now())
+                            .build();
+                })
+
+                .flatMap(eventRepository::save)
                 .then();
     }
 }


### PR DESCRIPTION
### 🔖 관련 티켓
SN-141 ([Jira 링크](https://crusia.atlassian.net/browse/SN-141))

<br>

### 📌 작업 개요 
- 이벤트 모달에 필요한 이메일 및 휴대폰 번호, nailTipId를 넘겨주는 로직
- ### ✅ 작업 항목 
- email, phone_number User 테이블에 추가 및 관련 DTO 추가
- 엔드포인트  /users/me/event 추가

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. 원제님과 논의해본 결과 사용자가 보관한 네일 세트를 기반으로 이벤트 응모가 가능하도록 기능을 추가했습니다.
2. 프론트는 네일 세트 저장 이후 응모 모달을 자동으로 띄우게 활성화 해놨고, 이벤트 응모시 와 만 넘기면 됩니다.
3. 동일한 유저가 중복 응모하는 기능은 일단 막아놨으며, 보관된 네일 세트 ID만 사용합니다. 추후 확장성까지 고려했을 때 보관 후에 응모하도록 하는게 일단은 맞는 것 같습니다.
4. 로컬 DB 기준으로 테스트 했을 때 확장된 테이블 및 컬럼은 다음과 같습니다.

 테이블(신규 추가)
uid=1001(runner) gid=118(docker) groups=118(docker),4(adm),100(users),999(systemd-journal) BIGINT(PK) 응모 식별자
 INT 응모한 사용자 ID(FK)
 INT 응모에 사용된 네일 세트 ID(FK)
 VARCHAR(255) 이메일(nullable)
 VARCHAR(20) 전화번호(nullable)
 DATETIME 응모 시각

 테이블은 따로 건든건 없습니다. 이벤트 테이블이 별도로 유지되어야 된다고 생각해서 일단 기존 서비스 안정성을 고려해서 별도로 유지했습니다.