### PR TITLE
chore: 임시파일 및 암호 키 추적 안 함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ out/
 src/**/resources/application*.properties
 src/**/resources/application*.yml
 !src/**/resources/application-example.properties
+
+### macOS ###
+.DS_Store
+
+### Secrets but injected by helm later ###
+*.p8


### PR DESCRIPTION
### 📝 추가 설명
1. `.DS_Store` 는 macOS에서 자동 생성되는 임시파일로 버전 관리 할 필요가 없습니다.
2. `*.p8` 은 우리 서비스에서 Apple 로그인을 위한 암호화 키입니다. 버전 관리에 추가하면 안 됩니다.
