### PR TITLE
[FEAT] 이벤트 참여 유무 항목 체크

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -122,4 +122,15 @@ public class UserController {
         return userService.submitEvent(payload.getUserId(), body)
                 .thenReturn(CommonResponse.success(null, "응모가 완료되었습니다."));
     }
+
+    /**
+     * 이벤트 응모 여부 조회
+     */
+    @GetMapping("/me/event-status")
+    public Mono<CommonResponse<Boolean>> checkEventStatus(
+            UserAuthByTokenPayload payload
+    ) {
+        return userService.eventStatus(payload.getUserId())
+                .map(flag -> CommonResponse.success(flag, "이벤트 응모 여부 조회 성공"));
+    }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -126,11 +126,11 @@ public class UserController {
     /**
      * 이벤트 응모 여부 조회
      */
-    @GetMapping("/me/event-status")
+    @GetMapping("/me/event")
     public Mono<CommonResponse<Boolean>> checkEventStatus(
             UserAuthByTokenPayload payload
     ) {
-        return userService.eventStatus(payload.getUserId())
+        return userService.hasEnrolledEvent(payload.getUserId())
                 .map(flag -> CommonResponse.success(flag, "이벤트 응모 여부 조회 성공"));
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -182,4 +182,8 @@ public class UserService {
                 .flatMap(eventRepository::save)
                 .then();
     }
+
+    public Mono<Boolean> eventStatus(int userId){
+        return eventRepository.existsByUserId(userId);
+    }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -183,7 +183,7 @@ public class UserService {
                 .then();
     }
 
-    public Mono<Boolean> eventStatus(int userId){
+    public Mono<Boolean> hasEnrolledEvent(int userId) {
         return eventRepository.existsByUserId(userId);
     }
 }


### PR DESCRIPTION
### 🔖 관련 티켓
SN-142 ([Jira 링크](https://crusia.atlassian.net/browse/SN-142))

<br>

### 📌 작업 개요 
- 유저가 이벤트에 최초 참여했는지 여부를 체크합니다.
- ### ✅ 작업 항목
- 이미 에러 메시지로 중복 응모에 대한 응답은 전달하고 있음
- 그러나 다른 기기에서 응모 접근 시에는 모달이 계속 올라오므로 이를 분리하기 위해 설계 

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. 사용자의 응모 여부를 boolean 값으로 반환
2. 프론트에서 이벤트 모달 노출 여부 판단에 사용 가능
3. DB는 수정사항 없으나 필요하다면 Unique 제약 조건 추가가 가능합니다.