### PR TITLE
[FEAT] 이벤트 응모시 이벤트 폴더에 자동 저장

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -3,7 +3,9 @@ package art.snail.naillian.backend.domain.user.service;
 import art.snail.naillian.backend.common.PageDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailImageUrlDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailSetEmbedDTO;
+import art.snail.naillian.backend.domain.nail.entity.NailFolderSet;
 import art.snail.naillian.backend.domain.nail.entity.NailTip;
+import art.snail.naillian.backend.domain.nail.repository.NailFolderSetRepository;
 import art.snail.naillian.backend.domain.nail.service.NailService;
 import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
@@ -18,6 +20,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
@@ -33,9 +37,12 @@ import java.util.regex.Pattern;
 public class UserService {
     private final UserRepository userRepository;
     private final EventSubmissionRepository eventRepository;
+    private final NailFolderSetRepository folderSetRepository;
     private static final Pattern EMAIL_OR_PHONE = Pattern.compile("(^[^@]+@[^@.]+\\.[^@.\\n]+$)|(^0[15-9][0-9]{1,2}-[0-9]{3,4}-[0-9]{3,5}$)");
     private final NailService nailService;
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
+
+    private static final int EVENT_FOLDER_ID = 4;
 
     /**
      * 기존 회원 정보 불러오기
@@ -156,18 +163,28 @@ public class UserService {
     /**
      * 아트 이벤트 응모
      */
+    @Transactional
     public Mono<Void> submitEvent(int userId, EventSubmissionDTO event) {
         if (!EMAIL_OR_PHONE.matcher(event.getUserInfo()).matches()) {
-            return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST,
-                    "입력하신 이메일 혹은 전화번호가 올바르지 않습니다."));
+            return Mono.error(new ReportableError(
+                    HttpStatus.BAD_REQUEST,
+                    "입력하신 이메일 혹은 전화번호가 올바르지 않습니다."
+            ));
         }
 
         return nailService.getNailSet(event.getNailSetId())
                 .filter(set -> Objects.equals(set.getUploadedBy(), userId))
-                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "네일 세트를 찾을 수 없습니다.")))
-                .zipWith(eventRepository.existsByUserId(userId)
-                        .filter(exists -> !exists)
-                        .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 응모하셨습니다.")))
+                .switchIfEmpty(Mono.error(new ReportableError(
+                        HttpStatus.NOT_FOUND,
+                        "네일 세트를 찾을 수 없습니다."
+                )))
+                .zipWith(
+                        eventRepository.existsByUserId(userId)
+                                .filter(exists -> !exists)
+                                .switchIfEmpty(Mono.error(new ReportableError(
+                                        HttpStatus.BAD_REQUEST,
+                                        "이미 응모하셨습니다."
+                                )))
                 )
                 .map(__ -> {
                     boolean isEmail = event.getUserInfo().contains("@");
@@ -180,6 +197,14 @@ public class UserService {
                             .build();
                 })
                 .flatMap(eventRepository::save)
+                .flatMap(saved ->
+                        folderSetRepository.save(new NailFolderSet(
+                                null,
+                                EVENT_FOLDER_ID,
+                                saved.getNailSetId(),
+                                LocalDateTime.now()
+                        ))
+                )
                 .then();
     }
 


### PR DESCRIPTION
### 🔖 관련 티켓
SN-147 ([Jira 링크](https://crusia.atlassian.net/browse/SN-147))

<br>

### 📌 작업 개요 
- 네일셋 응모시 폴더(어드민에서 볼 수 있게)에 매핑 되도록 수정
- ### ✅ 작업 항목 
- nailFolderId는 4번으로 고정(하드코딩) → 프론트에서 request body를 또 받아와야해서 일단은 4번으로 고정입니다.
- 향후 리팩토링 해야할 것 같습니다. 일단은 이벤트 로직이 촉박하여 하드코딩 했습니다.

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. 추가 설명 1
2. 추가 설명 2
3. and so on ...