### PR TITLE
[FIX] 회원탈퇴시 온보딩으로 돌아가지 않는 문제

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/SocialLoginRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/SocialLoginRepository.java
@@ -1,10 +1,17 @@
 package art.snail.naillian.backend.domain.user.repository;
 
 import art.snail.naillian.backend.domain.user.entity.SocialLogin;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 
 public interface SocialLoginRepository extends ReactiveCrudRepository<SocialLogin, Integer> {
+    @Query("""
+    SELECT *
+    FROM social_login
+    WHERE platform_user_id = :platformUserId
+      AND deleted_at IS NULL
+""")
     Mono<SocialLogin> findByPlatformUserId(String platformUserId);
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/UserRepository.java
@@ -1,9 +1,17 @@
 package art.snail.naillian.backend.domain.user.repository;
 
 import art.snail.naillian.backend.domain.user.entity.User;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 
 public interface UserRepository extends ReactiveCrudRepository<User, Integer> {
+
+    @Query("""
+    SELECT *
+    FROM user
+    WHERE nickname = :nickname
+      AND deleted_at IS NULL
+""")
     Mono<User> findByNickname(String nickname);
 }


### PR DESCRIPTION
### 🔖 관련 티켓
SN-149 ([Jira 링크](https://crusia.atlassian.net/browse/SN-149))

<br>

### 📌 작업 개요 
- QA 과정에서 회원탈퇴 후 재가입시 온보딩 화면이 아니라 메인화면으로 넘어가진다고 함
- ### ✅ 작업 항목 
- SocialLoginRepoistory랑 UserRepository에 soft delete 고려 쿼리를 추가함

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1. SocialLogin과 User Repository에 soft delete 관련 쿼리를 추가하여 재가입시 온보딩이 꼬이는 과정을 픽스했습니다.