### PR TITLE
[FEAT] 회원탈퇴시 온보딩으로 돌아가지 않는 문제

### DIFF
--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/SocialLogin.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/SocialLogin.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.time.LocalDateTime;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,4 +20,5 @@ public class SocialLogin {
     private Integer userId;
     private SocialPlatform platform;
     private String platformUserId;
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/SocialLoginRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/SocialLoginRepository.java
@@ -1,10 +1,26 @@
 package art.snail.naillian.backend.domain.user.repository;
 
 import art.snail.naillian.backend.domain.user.entity.SocialLogin;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 
 public interface SocialLoginRepository extends ReactiveCrudRepository<SocialLogin, Integer> {
+    @Query("""
+    SELECT *
+    FROM social_login
+    WHERE platform_user_id = :platformUserId
+    AND deleted_at IS NULL
+    """)
     Mono<SocialLogin> findByPlatformUserId(String platformUserId);
+
+    @Query("""
+    SELECT *
+    FROM social_login
+    WHERE user_id = :userId
+    AND deleted_at IS NULL
+    """)
+    Flux<SocialLogin> findAllByUserId(int userId);
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -11,11 +11,13 @@ import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
 import art.snail.naillian.backend.domain.user.dto.EventSubmissionDTO;
 import art.snail.naillian.backend.domain.user.entity.EventSubmission;
+import art.snail.naillian.backend.domain.user.entity.SocialLogin;
 import art.snail.naillian.backend.domain.user.entity.User;
 import art.snail.naillian.backend.domain.user.repository.EventSubmissionRepository;
 import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import art.snail.naillian.backend.errors.ReportableError;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +30,7 @@ import reactor.util.function.Tuple2;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -104,25 +106,42 @@ public class UserService {
     public Mono<Void> deleteUser(int userId) {
         return userRepository.findById(userId)
                 .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.GONE, "회원 정보가 존재하지 않습니다. 다시 로그인해주세요.")))
+                .filter(user -> user.getDeletedAt() == null)
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다.")))
                 .flatMap(user -> {
-                    if (user.getDeletedAt() != null) {
-                        return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다."));
-                    }
                     LocalDateTime now = LocalDateTime.now();
-                    user.setDeletedAt(now);
-                    return userRepository.save(user)
-                            .flatMap(savedUser ->
-                                    socialLoginRepository.findAllByUserId(userId)
-                                            .flatMap(sl -> {
-                                                sl.setDeletedAt(now);
-                                                long epoch = now.atZone(ZoneId.systemDefault()).toEpochSecond();
-                                                sl.setPlatformUserId(sl.getPlatformUserId() + "_deleted_at_" + epoch);
-                                                return socialLoginRepository.save(sl);
-                                            })
-                                            .then()
-                            );
-                })
-                .then();
+                    return softDeleteUser(user, now)
+                            .then(softDeleteSocialLoginEntry(userId, now).then());
+                });
+    }
+
+    /**
+     * 사용자를 삭제된 것으로 표기함
+     * @param userEntity 삭제하고자 하는 사용자 엔티티
+     * @param now 삭제되었다고 표기하려는 시간
+     * @return 저장된 엔티티
+     */
+    private Mono<User> softDeleteUser(User userEntity, @NonNull LocalDateTime now) {
+        return Mono.defer(() -> {
+            userEntity.setDeletedAt(now);
+            return userRepository.save(userEntity);
+        });
+    }
+
+    /**
+     * 사용자의 모든 소셜 로그인 정보를 삭제된 것으로 표기함
+     * @param userId 삭제하고자 하는 사용자의 id
+     * @param now 삭제되었다고 표기하려는 시간
+     * @return 저장된 소셜 로그인 정보
+     */
+    private Flux<SocialLogin> softDeleteSocialLoginEntry(int userId, LocalDateTime now) {
+        return socialLoginRepository.findAllByUserId(userId)
+                .flatMap(socialLogin -> {
+                    long epoch = now.toEpochSecond(ZoneOffset.UTC);
+                    socialLogin.setDeletedAt(now);
+                    socialLogin.setPlatformUserId(socialLogin.getPlatformUserId() + "_deleted_at_" + epoch);
+                    return socialLoginRepository.save(socialLogin);
+                });
     }
 
     /**

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import art.snail.naillian.backend.domain.user.dto.EventSubmissionDTO;
 import art.snail.naillian.backend.domain.user.entity.EventSubmission;
 import art.snail.naillian.backend.domain.user.entity.User;
 import art.snail.naillian.backend.domain.user.repository.EventSubmissionRepository;
+import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import art.snail.naillian.backend.errors.ReportableError;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import reactor.util.function.Tuple2;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,6 +45,7 @@ public class UserService {
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 
     private static final int EVENT_FOLDER_ID = 4;
+    private final SocialLoginRepository socialLoginRepository;
 
     /**
      * 기존 회원 정보 불러오기
@@ -105,8 +108,19 @@ public class UserService {
                     if (user.getDeletedAt() != null) {
                         return Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다."));
                     }
-                    user.setDeletedAt(LocalDateTime.now());
-                    return userRepository.save(user);
+                    LocalDateTime now = LocalDateTime.now();
+                    user.setDeletedAt(now);
+                    return userRepository.save(user)
+                            .flatMap(savedUser ->
+                                    socialLoginRepository.findAllByUserId(userId)
+                                            .flatMap(sl -> {
+                                                sl.setDeletedAt(now);
+                                                long epoch = now.atZone(ZoneId.systemDefault()).toEpochSecond();
+                                                sl.setPlatformUserId(sl.getPlatformUserId() + "_deleted_at_" + epoch);
+                                                return socialLoginRepository.save(sl);
+                                            })
+                                            .then()
+                            );
                 })
                 .then();
     }


### PR DESCRIPTION
### 🔖 관련 티켓
SN-149 ([Jira 링크](https://crusia.atlassian.net/browse/SN-149))

<br>

### 📌 작업 개요 
- QA 과정에서 회원탈퇴 후 재가입시 온보딩 화면이 아니라 메인화면으로 넘어가짐
- ### ✅ 작업 항목 
- 회원가입 후 탈퇴시 기존 로직은 soft-delete로 기존 데이터를 유지한 채 재가입이 되는 구조
- 이후 삭제시에 삭제된 계정은 일정 기간 유지하되 새로운 계정을 추가
- 재가입은 항상 가능하며, 일정 주기마다 수동 삭제 예정

<br>


<!--
이 위에 Jira 티켓의 내용이 자동으로 첨부됩니다.
Pull Request 가 생성된 이후 Jira 에서 수정하는 내용은 반영되지 않습니다.
-->

### 📝 추가 설명
1.  user.deleted_at 설정 (soft delete)
2.  social_login.platform_user_id → {원래값}_deleted_at_{UNIX_TIMESTAMP}로 덮어써서 중복 로그인 방지
3.  쿼리에  조건을 추가해 논리 삭제된 계정은 무시하도록 처리
4. 위 쿼리의 NULL 조건이 없으면 soft delete 된 유저도 여전히 쿼리 결과에 포함되어 온보딩 플로우에서 꼬임 현상이 발생하여 이를 예방하기 위해 명시적으로 soft delete 필터링을 추가했습니다
5. 테스트 플로우는 탈퇴 API 실행 후 DB에서 ,  변경 여부 확인했으며 동일 소셜 계정으로 재가입했을 때 새로운 user row 생성되는지 확인했습니다. 또한 새로 가입된 유저의 온보딩 상태가 0부터 시작하는지 검증했습니다
