### PR TITLE
[FEAT] personal nail 구현하기

### DIFF
--- a/src/main/java/art/snail/naillian/backend/common/S3Service.java
+++ b/src/main/java/art/snail/naillian/backend/common/S3Service.java
@@ -76,7 +76,7 @@ public class S3Service {
                 .cache(token -> Duration.ofMinutes(30), e -> Duration.ZERO, () -> Duration.ZERO)
                 .onErrorResume(e -> {
                     log.warn("Failed to retrieve data", e);
-                    return Mono.empty();
+                    return Mono.error(new ReportableError(HttpStatus.INTERNAL_SERVER_ERROR, "서버가 잘못 저장된 퍼스널 네일 진단 매핑을 갖고 있습니다."));
                 })
                 ;
     }

--- a/src/main/java/art/snail/naillian/backend/common/S3Service.java
+++ b/src/main/java/art/snail/naillian/backend/common/S3Service.java
@@ -72,8 +72,8 @@ public class S3Service {
                 .header("Accept", "application/json")
                 .retrieve()
                 .bodyToMono(JsonNode.class)
-                .cache(Duration.ofHours(1))
                 .map(this::parseToPersonalNailMapping)
+                .cache(token -> Duration.ofMinutes(30), e -> Duration.ZERO, () -> Duration.ZERO)
                 .onErrorResume(e -> {
                     log.warn("Failed to retrieve data", e);
                     return Mono.empty();

--- a/src/main/java/art/snail/naillian/backend/common/S3Service.java
+++ b/src/main/java/art/snail/naillian/backend/common/S3Service.java
@@ -42,11 +42,14 @@ public class S3Service {
                 .header("Accept", "application/json")
                 .retrieve()
                 .bodyToMono(JsonNode.class)
-                .cache(Duration.ofHours(1))
                 .map(this::parseToNailVariants)
+                .cache(token -> Duration.ofMinutes(30), e -> Duration.ZERO, () -> Duration.ZERO)
                 .onErrorResume(e -> {
+                    if (e instanceof ReportableError)
+                        return Mono.error(e);
+
                     log.warn("Failed to retrieve data", e);
-                    return Mono.empty();
+                    return Mono.error(new ReportableError(HttpStatus.INTERNAL_SERVER_ERROR, "진단 결과를 가져오는 도중 오류가 발생했습니다."));
                 })
                 ;
     }

--- a/src/main/java/art/snail/naillian/backend/common/S3Service.java
+++ b/src/main/java/art/snail/naillian/backend/common/S3Service.java
@@ -1,15 +1,28 @@
 package art.snail.naillian.backend.common;
 
 import art.snail.naillian.backend.config.ModelConfig;
+import art.snail.naillian.backend.domain.user.dto.PersonalNailStatusDto;
+import art.snail.naillian.backend.errors.ReportableError;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class S3Service {
+    private static final Logger log = LoggerFactory.getLogger(S3Service.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final WebClient webClient;
     private final ModelConfig modelConfig;
@@ -21,5 +34,35 @@ public class S3Service {
                 .retrieve()
                 .bodyToMono(JsonNode.class)
                 .onErrorResume(e -> Mono.empty());
+    }
+
+    public Mono<Map<String, PersonalNailStatusDto>> getPersonalNailVariants() {
+        return webClient.get()
+                .uri(modelConfig.getPersonalNailVariantsUrl())
+                .header("Accept", "application/json")
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .cache(Duration.ofHours(1))
+                .map(this::parseToNailVariants)
+                .onErrorResume(e -> {
+                    log.warn("Failed to retrieve data", e);
+                    return Mono.empty();
+                })
+                ;
+    }
+
+    private Map<String, PersonalNailStatusDto> parseToNailVariants(JsonNode node) {
+        Map<String, PersonalNailStatusDto> map = new HashMap<>();
+        for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
+            String fieldName = it.next();
+
+            try {
+                PersonalNailStatusDto dto = objectMapper.readValue(node.get(fieldName).toString(), PersonalNailStatusDto.class);
+                map.put(fieldName, dto);
+            } catch (Exception e) {
+                throw new ReportableError(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 저장된 네일 정보가 잘못된 형식을 갖고 있습니다.");
+            }
+        }
+        return map;
     }
 }

--- a/src/main/java/art/snail/naillian/backend/common/S3Service.java
+++ b/src/main/java/art/snail/naillian/backend/common/S3Service.java
@@ -65,4 +65,28 @@ public class S3Service {
         }
         return map;
     }
+
+    public Mono<Map<String, Integer>> getPersonalNailMapping() {
+        return webClient.get()
+                .uri(modelConfig.getPersonalNailMappingUrl())
+                .header("Accept", "application/json")
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .cache(Duration.ofHours(1))
+                .map(this::parseToPersonalNailMapping)
+                .onErrorResume(e -> {
+                    log.warn("Failed to retrieve data", e);
+                    return Mono.empty();
+                })
+                ;
+    }
+
+    private Map<String, Integer> parseToPersonalNailMapping(JsonNode node) {
+        Map<String, Integer> map = new HashMap<>();
+        for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
+            String fieldName = it.next();
+            map.put(fieldName, node.get(fieldName).asInt());
+        }
+        return map;
+    }
 }

--- a/src/main/java/art/snail/naillian/backend/config/ModelConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/ModelConfig.java
@@ -1,16 +1,15 @@
 package art.snail.naillian.backend.config;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix = "cloudfront")
 @Getter
+@Setter
 public class ModelConfig {
     private String s3ModelUrl;
-
-    public void setS3ModelUrl(String s3ModelUrl) {
-        this.s3ModelUrl = s3ModelUrl;
-    }
+    private String personalNailVariantsUrl;
 }

--- a/src/main/java/art/snail/naillian/backend/config/ModelConfig.java
+++ b/src/main/java/art/snail/naillian/backend/config/ModelConfig.java
@@ -12,4 +12,5 @@ import org.springframework.context.annotation.Configuration;
 public class ModelConfig {
     private String s3ModelUrl;
     private String personalNailVariantsUrl;
+    private String personalNailMappingUrl;
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -136,9 +136,12 @@ public class UserController {
 
     @PostMapping("/me/personal-nail")
     public Mono<CommonResponse<PersonalNailStatusDto>> submitPersonalNailSelection(
+            UserAuthByTokenPayload payload,
             @RequestBody CreatePersonalNailStatusDto dto
     ) {
-        throw new RuntimeException("not implemented");
+        return this.userService.submitUserPersonalNailStatus(payload.getUserId(), dto.getSteps())
+                .map(data -> CommonResponse.success(data, "진단이 완료되었습니다."))
+                ;
     }
 
     @GetMapping("/me/personal-nail")

--- a/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/controller/UserController.java
@@ -133,4 +133,19 @@ public class UserController {
         return userService.hasEnrolledEvent(payload.getUserId())
                 .map(flag -> CommonResponse.success(flag, "이벤트 응모 여부 조회 성공"));
     }
+
+    @PostMapping("/me/personal-nail")
+    public Mono<CommonResponse<PersonalNailStatusDto>> submitPersonalNailSelection(
+            @RequestBody CreatePersonalNailStatusDto dto
+    ) {
+        throw new RuntimeException("not implemented");
+    }
+
+    @GetMapping("/me/personal-nail")
+    public Mono<CommonResponse<PersonalNailStatusDto>> checkPersonalNailStatus(
+            UserAuthByTokenPayload payload
+    ) {
+        return this.userService.getUserNailStatus(payload.getUserId())
+                .map(CommonResponse::success);
+    }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/CreatePersonalNailStatusDto.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/CreatePersonalNailStatusDto.java
@@ -1,0 +1,10 @@
+package art.snail.naillian.backend.domain.user.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CreatePersonalNailStatusDto {
+    private List<Integer> steps;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/PersonalNailStatusDto.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/PersonalNailStatusDto.java
@@ -1,0 +1,24 @@
+package art.snail.naillian.backend.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PersonalNailStatusDto {
+    private String title;
+    private String description;
+    private List<String> tags;
+
+    @JsonProperty("icon_url")
+    private String iconUrl;
+
+    @JsonProperty("background_color")
+    private Integer backgroundColor;
+
+    @JsonProperty("set_ids")
+    private List<Integer> setIds;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/PersonalNailStatusDto.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/PersonalNailStatusDto.java
@@ -1,6 +1,7 @@
 package art.snail.naillian.backend.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PersonalNailStatusDto {
     private String title;
     private String description;

--- a/src/main/java/art/snail/naillian/backend/domain/user/dto/PersonalNailVariants.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/dto/PersonalNailVariants.java
@@ -1,0 +1,6 @@
+package art.snail.naillian.backend.domain.user.dto;
+
+import java.util.Map;
+
+public abstract class PersonalNailVariants implements Map<String, PersonalNailStatusDto> {
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/UserPersonalNail.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/UserPersonalNail.java
@@ -1,10 +1,12 @@
 package art.snail.naillian.backend.domain.user.entity;
 
+import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Data
+@Builder
 @Table("user_personal_nail")
 public class UserPersonalNail {
     @Id

--- a/src/main/java/art/snail/naillian/backend/domain/user/entity/UserPersonalNail.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/entity/UserPersonalNail.java
@@ -1,0 +1,14 @@
+package art.snail.naillian.backend.domain.user.entity;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@Table("user_personal_nail")
+public class UserPersonalNail {
+    @Id
+    private Integer id;
+    private Integer userId;
+    private Integer variantId;
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/UserPersonalNailRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/UserPersonalNailRepository.java
@@ -6,4 +6,6 @@ import reactor.core.publisher.Mono;
 
 public interface UserPersonalNailRepository extends ReactiveCrudRepository<UserPersonalNail, Integer> {
     Mono<UserPersonalNail> findByUserId(Integer userId);
+
+    Mono<Void> deleteAllByUserId(Integer userId);
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/repository/UserPersonalNailRepository.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/repository/UserPersonalNailRepository.java
@@ -1,0 +1,9 @@
+package art.snail.naillian.backend.domain.user.repository;
+
+import art.snail.naillian.backend.domain.user.entity.UserPersonalNail;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface UserPersonalNailRepository extends ReactiveCrudRepository<UserPersonalNail, Integer> {
+    Mono<UserPersonalNail> findByUserId(Integer userId);
+}

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -270,5 +271,31 @@ public class UserService {
                     return variants.get(tuple.getT2());
                 })
                 .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "존재하지 않는 진단 정보를 갖고 있습니다.")));
+    }
+
+    public Mono<PersonalNailStatusDto> submitUserPersonalNailStatus(Integer userId, List<Integer> selections) {
+        return getUserById(userId)
+                .then(this.personalNailRepository.deleteAllByUserId(userId))
+                .then(this.s3Service.getPersonalNailMapping())
+                .zipWith(
+                        Flux.fromIterable(selections)
+                                .map(Object::toString)
+                                .collect(Collectors.joining(""))
+                )
+                .mapNotNull(tuple -> tuple.getT1().get(tuple.getT2()))
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.BAD_REQUEST, "올바르지 않은 설문 결과입니다.")))
+                .flatMap(variantId -> this.saveUserPersonalNailAndReturnVariantId(userId, variantId)
+                        .then(this.s3Service.getPersonalNailVariants())
+                        .map(map -> map.get(variantId.toString()))
+                );
+    }
+
+    private Mono<Integer> saveUserPersonalNailAndReturnVariantId(Integer userId, Integer variantId) {
+        return Mono.fromCallable(() -> UserPersonalNail.builder()
+                        .userId(userId)
+                        .variantId(variantId)
+                        .build()
+                ).flatMap(this.personalNailRepository::save)
+                .then(Mono.just(variantId));
     }
 }

--- a/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
+++ b/src/main/java/art/snail/naillian/backend/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package art.snail.naillian.backend.domain.user.service;
 
 import art.snail.naillian.backend.common.PageDTO;
+import art.snail.naillian.backend.common.S3Service;
 import art.snail.naillian.backend.domain.nail.dto.NailImageUrlDTO;
 import art.snail.naillian.backend.domain.nail.dto.NailSetEmbedDTO;
 import art.snail.naillian.backend.domain.nail.entity.NailFolderSet;
@@ -10,11 +11,14 @@ import art.snail.naillian.backend.domain.nail.service.NailService;
 import art.snail.naillian.backend.domain.onboarding.entity.OnboardingStep;
 import art.snail.naillian.backend.domain.onboarding.service.OnboardingService;
 import art.snail.naillian.backend.domain.user.dto.EventSubmissionDTO;
+import art.snail.naillian.backend.domain.user.dto.PersonalNailStatusDto;
 import art.snail.naillian.backend.domain.user.entity.EventSubmission;
 import art.snail.naillian.backend.domain.user.entity.SocialLogin;
 import art.snail.naillian.backend.domain.user.entity.User;
+import art.snail.naillian.backend.domain.user.entity.UserPersonalNail;
 import art.snail.naillian.backend.domain.user.repository.EventSubmissionRepository;
 import art.snail.naillian.backend.domain.user.repository.SocialLoginRepository;
+import art.snail.naillian.backend.domain.user.repository.UserPersonalNailRepository;
 import art.snail.naillian.backend.domain.user.repository.UserRepository;
 import art.snail.naillian.backend.errors.ReportableError;
 import lombok.NonNull;
@@ -32,6 +36,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -42,7 +47,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final EventSubmissionRepository eventRepository;
     private final NailFolderSetRepository folderSetRepository;
+    private final UserPersonalNailRepository personalNailRepository;
+
     private static final Pattern EMAIL_OR_PHONE = Pattern.compile("(^[^@]+@[^@.]+\\.[^@.\\n]+$)|(^0[15-9][0-9]{1,2}-[0-9]{3,4}-[0-9]{3,5}$)");
+    private final S3Service s3Service;
     private final NailService nailService;
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,8}$");
 
@@ -243,5 +251,24 @@ public class UserService {
 
     public Mono<Boolean> hasEnrolledEvent(int userId) {
         return eventRepository.existsByUserId(userId);
+    }
+
+    private Mono<String> getPersonalNailVariantIdByUserId(Integer userId) {
+        return getUserById(userId)
+                .flatMap(user -> personalNailRepository.findByUserId(user.getId()))
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "진단 정보가 없습니다.")))
+                .map(UserPersonalNail::getVariantId)
+                .map(Object::toString);
+    }
+
+    public Mono<PersonalNailStatusDto> getUserNailStatus(Integer userId) {
+        return this.s3Service.getPersonalNailVariants()
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.INTERNAL_SERVER_ERROR, "진단 정보 셋을 받아오는데 실패했습니다.")))
+                .zipWith(this.getPersonalNailVariantIdByUserId(userId))
+                .mapNotNull(tuple -> {
+                    Map<String, PersonalNailStatusDto> variants = tuple.getT1();
+                    return variants.get(tuple.getT2());
+                })
+                .switchIfEmpty(Mono.error(new ReportableError(HttpStatus.NOT_FOUND, "존재하지 않는 진단 정보를 갖고 있습니다.")));
     }
 }


### PR DESCRIPTION
### 🔖 관련 티켓
SN-152 ([Jira 링크](https://crusia.atlassian.net/browse/SN-152))

### 📌 작업 개요 
퍼스널 네일 진단하기 기능을 구현합니다

### ✅ 작업 항목 
- 진단 정보 불러오기
- 진단 정보 저장하기
- 서버(S3)로부터 진단 매핑 가져오기

---

1. 각 퍼스널 네일 정보와 퍼스널 네일로의 매핑(진단) 정보는 S3에 json 형태로 보관했습니다. (DB보다는 static에 가까워서)

